### PR TITLE
✨ [FEAT] 게시글 CRUD API 구현 (#14)

### DIFF
--- a/src/main/java/com/example/template/FillEnergyApplication.java
+++ b/src/main/java/com/example/template/FillEnergyApplication.java
@@ -6,10 +6,10 @@ import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
 @EnableJpaAuditing
-public class SmupoolApplication {
+public class FillEnergyApplication {
 
 	public static void main(String[] args) {
-		SpringApplication.run(SmupoolApplication.class, args);
+		SpringApplication.run(FillEnergyApplication.class, args);
 	}
 
 }

--- a/src/main/java/com/example/template/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/template/domain/board/controller/BoardController.java
@@ -1,0 +1,90 @@
+package com.example.template.domain.board.controller;
+
+import com.example.template.domain.board.dto.request.BoardRequestDTO;
+import com.example.template.domain.board.dto.response.BoardResponseDTO;
+import com.example.template.domain.board.entity.enums.Category;
+import com.example.template.domain.board.entity.enums.HelpStatus;
+import com.example.template.domain.board.service.commandService.BoardCommandService;
+import com.example.template.domain.board.service.queryService.BoardQueryService;
+import com.example.template.global.apiPayload.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+
+
+@Slf4j
+@RestController
+@RequestMapping("/api/v1/boards")
+@RequiredArgsConstructor
+public class BoardController {
+
+    private final BoardQueryService boardQueryService;
+    private final BoardCommandService boardCommandService;
+
+    // TODO: 커서 적용해서 목록 조회 예정
+    // 게시글 목록 조회 (전체 및 카테고리별)
+//    @GetMapping("/{category}/{cursor}/{limit}")
+//    public ApiResponse<BoardResponseDTO.BoardListDTO> getBoardList(
+//            @PathVariable(required = false) Category category,
+//            @PathVariable Long cursor,
+//            @PathVariable Integer limit,
+//            @RequestParam(defaultValue = "latest") String sort) {
+//        return ApiResponse.onSuccess(boardQueryService.getBoardList(category, cursor, limit, sort));
+//    }
+
+    // 게시글 상세 조회 (단일 게시글)
+    @GetMapping("/{boardId}")
+    public ApiResponse<BoardResponseDTO.BoardDetailDTO> getBoardDetail(@PathVariable Long boardId) {
+        return ApiResponse.onSuccess(boardQueryService.getBoardDetail(boardId));
+    }
+
+    // TODO : 내 게시글 조회 (보류 : 아직 디자인 안나옴)
+
+    // 게시글 작성
+    @PostMapping
+    public ResponseEntity<ApiResponse<BoardResponseDTO.BoardDTO>> createBoard(
+            @Valid @RequestBody BoardRequestDTO.CreateBoardDTO createBoardDTO) {
+        // 201 Created 사용
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.onSuccess(HttpStatus.CREATED, boardCommandService.createBoard(createBoardDTO)));
+    }
+
+    // 게시글 수정
+    @PutMapping("/{boardId}")
+    public ApiResponse<BoardResponseDTO.BoardDTO> updateBoard(
+            @PathVariable Long boardId,
+            @Valid @RequestBody BoardRequestDTO.UpdateBoardDTO updateBoardDTO) {
+        return ApiResponse.onSuccess(boardCommandService.updateBoard(boardId, updateBoardDTO));
+    }
+
+    // 게시글 삭제
+    @DeleteMapping("/{boardId}")
+    public ApiResponse<Long> deleteBoard(@PathVariable Long boardId) {
+        return ApiResponse.onSuccess(boardCommandService.deleteBoard(boardId));
+    }
+
+    // 게시글 상태 변경 (도와줘요 카테고리)
+    @PatchMapping("/{boardId}/status")
+    public ApiResponse<BoardResponseDTO.BoardStatusDTO> updateBoardStatus(
+            @PathVariable Long boardId,
+            @Valid @RequestBody BoardRequestDTO.UpdateBoardStatusDTO updateBoardStatusDTO) {
+        return ApiResponse.onSuccess(boardCommandService.updateBoardStatus(boardId, updateBoardStatusDTO));
+    }
+
+    // 게시글 좋아요 추가
+    @PostMapping("/{boardId}/likes")
+    public ApiResponse<BoardResponseDTO.BoardLikeDTO> addLike(@PathVariable Long boardId) {
+        return ApiResponse.onSuccess(boardCommandService.addLike(boardId));
+    }
+
+    // 게시글 좋아요 삭제
+    @DeleteMapping("/{boardId}/likes")
+    public ApiResponse<BoardResponseDTO.BoardLikeDTO> removeLike(@PathVariable Long boardId) {
+        return ApiResponse.onSuccess(boardCommandService.removeLike(boardId));
+    }
+}

--- a/src/main/java/com/example/template/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/template/domain/board/controller/BoardController.java
@@ -7,6 +7,7 @@ import com.example.template.domain.board.entity.enums.HelpStatus;
 import com.example.template.domain.board.service.commandService.BoardCommandService;
 import com.example.template.domain.board.service.queryService.BoardQueryService;
 import com.example.template.global.apiPayload.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,36 +26,22 @@ public class BoardController {
     private final BoardQueryService boardQueryService;
     private final BoardCommandService boardCommandService;
 
-    // TODO: 커서 적용해서 목록 조회 예정
-    // 게시글 목록 조회 (전체 및 카테고리별)
-//    @GetMapping("/{category}/{cursor}/{limit}")
-//    public ApiResponse<BoardResponseDTO.BoardListDTO> getBoardList(
-//            @PathVariable(required = false) Category category,
-//            @PathVariable Long cursor,
-//            @PathVariable Integer limit,
-//            @RequestParam(defaultValue = "latest") String sort) {
-//        return ApiResponse.onSuccess(boardQueryService.getBoardList(category, cursor, limit, sort));
-//    }
-
-    // 게시글 상세 조회 (단일 게시글)
+    @Operation(summary = "게시글 상세 조회", description = "지정된 ID의 게시글 상세 정보를 조회합니다.")
     @GetMapping("/{boardId}")
-    public ApiResponse<BoardResponseDTO.BoardDetailDTO> getBoardDetail(@PathVariable Long boardId) {
+    public ApiResponse<BoardResponseDTO.BoardDetailDTO> getBoardDetail(@PathVariable("boardId") Long boardId) {
         return ApiResponse.onSuccess(boardQueryService.getBoardDetail(boardId));
     }
 
-    // TODO : 내 게시글 조회 (보류 : 아직 디자인 안나옴)
-
-    // 게시글 작성
+    @Operation(summary = "게시글 작성", description = "새로운 게시글을 작성합니다.")
     @PostMapping
     public ResponseEntity<ApiResponse<BoardResponseDTO.BoardDTO>> createBoard(
             @Valid @RequestBody BoardRequestDTO.CreateBoardDTO createBoardDTO) {
-        // 201 Created 사용
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.onSuccess(HttpStatus.CREATED, boardCommandService.createBoard(createBoardDTO)));
     }
 
-    // 게시글 수정
+    @Operation(summary = "게시글 수정", description = "지정된 ID의 게시글을 수정합니다.")
     @PutMapping("/{boardId}")
     public ApiResponse<BoardResponseDTO.BoardDTO> updateBoard(
             @PathVariable Long boardId,
@@ -62,13 +49,13 @@ public class BoardController {
         return ApiResponse.onSuccess(boardCommandService.updateBoard(boardId, updateBoardDTO));
     }
 
-    // 게시글 삭제
+    @Operation(summary = "게시글 삭제", description = "지정된 ID의 게시글을 삭제합니다.")
     @DeleteMapping("/{boardId}")
     public ApiResponse<Long> deleteBoard(@PathVariable Long boardId) {
         return ApiResponse.onSuccess(boardCommandService.deleteBoard(boardId));
     }
 
-    // 게시글 상태 변경 (도와줘요 카테고리)
+    @Operation(summary = "게시글 상태 변경", description = "도와줘요 카테고리의 게시글 상태를 변경합니다.")
     @PatchMapping("/{boardId}/status")
     public ApiResponse<BoardResponseDTO.BoardStatusDTO> updateBoardStatus(
             @PathVariable Long boardId,
@@ -76,15 +63,15 @@ public class BoardController {
         return ApiResponse.onSuccess(boardCommandService.updateBoardStatus(boardId, updateBoardStatusDTO));
     }
 
-    // 게시글 좋아요 추가
+    @Operation(summary = "게시글 좋아요 추가", description = "지정된 게시글에 좋아요를 추가합니다.")
     @PostMapping("/{boardId}/likes")
-    public ApiResponse<BoardResponseDTO.BoardLikeDTO> addLike(@PathVariable Long boardId) {
+    public ApiResponse<BoardResponseDTO.BoardLikeDTO> addLike(@PathVariable("boardId") Long boardId) {
         return ApiResponse.onSuccess(boardCommandService.addLike(boardId));
     }
 
-    // 게시글 좋아요 삭제
+    @Operation(summary = "게시글 좋아요 삭제", description = "지정된 게시글의 좋아요를 삭제합니다.")
     @DeleteMapping("/{boardId}/likes")
-    public ApiResponse<BoardResponseDTO.BoardLikeDTO> removeLike(@PathVariable Long boardId) {
+    public ApiResponse<BoardResponseDTO.BoardLikeDTO> removeLike(@PathVariable("boardId") Long boardId) {
         return ApiResponse.onSuccess(boardCommandService.removeLike(boardId));
     }
 }

--- a/src/main/java/com/example/template/domain/board/controller/CommentController.java
+++ b/src/main/java/com/example/template/domain/board/controller/CommentController.java
@@ -1,0 +1,42 @@
+package com.example.template.domain.board.controller;
+
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/boards")
+public class CommentController {
+
+    // TODO : 댓글 CRUD 구현
+//    private CommentQueryService commentQueryService;
+//    private CommentCommandService commentCommandService;
+//
+//    @GetMapping
+//    public ApiResponse<List<CommentResponseDTO>> getCommentList(@PathVariable Long boardId) {
+//        List<CommentResponseDTO> comments = commentQueryService.getCommentList(boardId);
+//        return ApiResponse.onSuccess(comments);
+//    }
+//
+//    @PostMapping
+//    public ApiResponse<Long> createComment(@PathVariable Long boardId, @RequestBody CommentRequestDTO commentRequestDTO) {
+//        Long commentId = commentCommandService.createComment(boardId, commentRequestDTO);
+//        return ApiResponse.onSuccess(HttpStatus.CREATED, commentId);
+//    }
+//
+//    @PutMapping("/{commentId}")
+//    public ApiResponse<Long> updateComment(@PathVariable Long boardId, @PathVariable Long commentId, @RequestBody CommentRequestDTO commentRequestDTO) {
+//        Long updatedCommentId = commentCommandService.updateComment(boardId, commentId, commentRequestDTO);
+//        return ApiResponse.onSuccess(updatedCommentId);
+//    }
+//
+//    @DeleteMapping("/{commentId}")
+//    public ApiResponse<Void> deleteComment(@PathVariable Long boardId, @PathVariable Long commentId) {
+//        commentCommandService.deleteComment(boardId, commentId);
+//        return ApiResponse.onSuccess(null);
+//    }
+}

--- a/src/main/java/com/example/template/domain/board/dto/request/BoardRequestDTO.java
+++ b/src/main/java/com/example/template/domain/board/dto/request/BoardRequestDTO.java
@@ -1,0 +1,77 @@
+package com.example.template.domain.board.dto.request;
+
+import com.example.template.domain.board.entity.Board;
+import com.example.template.domain.board.entity.BoardImg;
+import com.example.template.domain.board.entity.enums.Category;
+import com.example.template.domain.board.entity.enums.HelpStatus;
+import com.example.template.domain.member.entity.Member;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Getter;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class BoardRequestDTO {
+    @Getter
+    public static class CreateBoardDTO {
+        @NotNull(message = "제목은 필수입니다.")
+        @Size(max = 30, message = "제목은 30자를 초과할 수 없습니다.")
+        private String title;
+
+        @NotNull(message = "내용은 필수입니다.")
+        private String content;
+
+        @NotNull(message = "카테고리는 필수입니다.")
+        private Category category;
+
+        private List<String> images; // 엔티티에 없는 필드, 별도 처리 필요
+
+        public Board toEntity(Member member) {
+            HelpStatus helpStatus = this.category == Category.HELP ? HelpStatus.REQUESTED : HelpStatus.NONE;
+            Board board = Board.builder()
+                    .title(title)
+                    .content(content)
+                    .category(category)
+                    .helpStatus(helpStatus)
+                    .member(member)
+                    .likeNum(0)
+                    .commentCount(0)
+                    .images(new ArrayList<>())
+                    .build();
+
+            // images가 null이 아닌 경우 처리
+            if (images != null) {
+                for (String imageUrl : images) {
+                    BoardImg boardImg = BoardImg.builder()
+                            .boardImgUrl(imageUrl)
+                            .build();
+                    boardImg.setBoard(board);
+                }
+            }
+            return board;
+        }
+    }
+
+    @Getter
+    public static class UpdateBoardDTO {
+        @NotNull(message = "제목은 필수입니다.")
+        @Size(max = 30, message = "제목은 30자를 초과할 수 없습니다.")
+        private String title;
+
+        @NotNull(message = "내용은 필수입니다.")
+        private String content;
+
+        @NotNull(message = "카테고리는 필수입니다.")
+        private Category category;
+
+        private List<String> images; // 엔티티에 없는 필드, 별도 처리 필요
+    }
+
+    @Getter
+    public static class UpdateBoardStatusDTO {
+        @NotNull(message = "상태는 필수 입력값입니다.")
+        private HelpStatus helpStatus;
+    }
+}

--- a/src/main/java/com/example/template/domain/board/dto/response/BoardResponseDTO.java
+++ b/src/main/java/com/example/template/domain/board/dto/response/BoardResponseDTO.java
@@ -1,0 +1,114 @@
+package com.example.template.domain.board.dto.response;
+
+import com.example.template.domain.board.entity.Board;
+import com.example.template.domain.board.entity.BoardImg;
+import com.example.template.domain.board.entity.Comment;
+import com.example.template.domain.board.entity.enums.Category;
+import com.example.template.domain.board.entity.enums.HelpStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class BoardResponseDTO {
+    @Getter
+    @Builder
+    public static class BoardDTO {
+        private Long id;
+        private Long memberId;
+        private String memberName;
+        private String title;
+        private String content;
+        private Category category;
+        private HelpStatus helpStatus;
+        private Boolean isAuthor;
+        private Integer likeNum;
+        private Integer commentCount;
+        private LocalDateTime createdAt;
+        private LocalDateTime updatedAt;
+        private List<String> images;
+
+        public static BoardDTO from(Board board, Long currentMemberId) {
+            return BoardDTO.builder()
+                    .id(board.getId())
+                    .memberId(board.getMember().getId())
+                    .memberName(board.getMember().getName())
+                    .title(board.getTitle())
+                    .content(board.getContent())
+                    .category(board.getCategory())
+                    .helpStatus(board.getHelpStatus())
+                    .isAuthor(board.getMember().getId().equals(currentMemberId))
+                    .likeNum(board.getLikeNum())
+                    .commentCount(board.getCommentCount())
+                    .images(board.getImages().stream().map(BoardImg::getBoardImgUrl).toList())
+                    .createdAt(board.getCreatedAt())
+                    .updatedAt(board.getUpdatedAt())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class BoardListDTO {
+        private List<BoardDTO> boards;
+        private Long nextCursor;
+        private boolean hasNext;
+
+        public static BoardListDTO of(List<Board> boards, Long nextCursor, boolean hasNext, Long currentMemberId) {
+            List<BoardDTO> boardDTOs = boards.stream()
+                    .map(board -> BoardDTO.from(board, currentMemberId))
+                    .toList();
+
+            return BoardListDTO.builder()
+                    .boards(boardDTOs)
+                    .nextCursor(nextCursor)
+                    .hasNext(hasNext)
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class BoardDetailDTO {
+        private BoardDTO board;
+        private List<CommentResponseDTO.CommentDTO> comments;
+
+        public static BoardDetailDTO of(Board board, List<Comment> comments, Long currentMemberId) {
+            return BoardDetailDTO.builder()
+                    .board(BoardDTO.from(board, currentMemberId))
+                    .comments(comments.stream().map(CommentResponseDTO.CommentDTO::from).toList())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class BoardStatusDTO {
+        private Long boardId;
+        private String helpStatus;
+
+        public static BoardStatusDTO from(Board board) {
+            return BoardStatusDTO.builder()
+                    .boardId(board.getId())
+                    .helpStatus(board.getHelpStatus().name())
+                    .build();
+        }
+    }
+
+    @Getter
+    @Builder
+    public static class BoardLikeDTO {
+        private Long memberId;
+        private Long boardId;
+        private Integer likeCount;
+
+        public static BoardLikeDTO from(Board board, Long currentMemberId) {
+            return BoardLikeDTO.builder()
+                    .memberId(currentMemberId)
+                    .boardId(board.getId())
+                    .likeCount(board.getLikeNum())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/template/domain/board/dto/response/CommentResponseDTO.java
+++ b/src/main/java/com/example/template/domain/board/dto/response/CommentResponseDTO.java
@@ -1,0 +1,36 @@
+package com.example.template.domain.board.dto.response;
+
+import com.example.template.domain.board.entity.Comment;
+import com.example.template.domain.board.entity.CommentImg;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public class CommentResponseDTO {
+
+    @Getter
+    @Builder
+    public static class CommentDTO {
+        private Long id;
+        private String content;
+        private boolean isSecret;
+        private Long memberId;
+        private String memberName;
+        private LocalDateTime createdAt;
+        private List<String> images;
+
+        public static CommentDTO from(Comment comment) {
+            return CommentDTO.builder()
+                    .id(comment.getId())
+                    .content(comment.isSecret() ? "비밀 댓글입니다." : comment.getContent())
+                    .isSecret(comment.isSecret())
+                    .memberId(comment.getMember().getId())
+                    .memberName(comment.getMember().getName())
+                    .createdAt(comment.getCreatedAt())
+                    .images(comment.getImages().stream().map(CommentImg::getCommentImgUrl).toList())
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/example/template/domain/board/entity/Board.java
+++ b/src/main/java/com/example/template/domain/board/entity/Board.java
@@ -7,6 +7,9 @@ import com.example.template.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Builder
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -20,24 +23,54 @@ public class Board extends BaseEntity {
     private Long id;
 
     @Column(nullable = false, length = 30)
-    private String title;   // 제목
+    private String title;     // 제목
 
     @Lob
     @Column(nullable = false)
-    private String content; // 내용
+    private String content;   // 내용
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false)
-    private Category category;    // 카테고리
+    private Category category;     // 카테고리
 
     @Enumerated(EnumType.STRING)
     @Column(name = "help_status", nullable = false)
-    private HelpStatus helpStatus;  // 도움 상태
+    private HelpStatus helpStatus; // 도움 상태
 
     @Column(name = "like_num")
-    private Integer likeNum;    // 좋아요 수
+    private Integer likeNum;       // 좋아요 수
+
+    @Column(name = "comment_count")
+    private Integer commentCount;  // 댓글 수
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
+
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<BoardImg> images = new ArrayList<>();
+
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Comment> comments = new ArrayList<>();
+
+    // Setter 메서드
+    public void update(String title, String content, Category category) {
+        this.title = title;
+        this.content = content;
+        this.category = category;
+    }
+
+    public void incrementLikeCount() {
+        this.likeNum = (this.likeNum == null) ? 1 : this.likeNum + 1;
+    }
+
+    public void decrementLikeCount() {
+        if (this.likeNum != null && this.likeNum > 0) {
+            this.likeNum--;
+        }
+    }
+
+    public void updateHelpStatus(HelpStatus helpStatus) {
+        this.helpStatus = helpStatus;
+    }
 }

--- a/src/main/java/com/example/template/domain/board/entity/Board.java
+++ b/src/main/java/com/example/template/domain/board/entity/Board.java
@@ -1,5 +1,7 @@
 package com.example.template.domain.board.entity;
 
+import com.example.template.domain.board.entity.enums.Category;
+import com.example.template.domain.board.entity.enums.HelpStatus;
 import com.example.template.domain.member.entity.Member;
 import com.example.template.global.common.BaseEntity;
 import jakarta.persistence.*;

--- a/src/main/java/com/example/template/domain/board/entity/BoardImg.java
+++ b/src/main/java/com/example/template/domain/board/entity/BoardImg.java
@@ -21,4 +21,17 @@ public class BoardImg {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id")
     private Board board;
+
+    // Setter 메서드
+    public void setBoardImgUrl(String boardImgUrl) {
+        this.boardImgUrl = boardImgUrl;
+    }
+
+    // 연관관계 편의 메서드
+    public void setBoard(Board board){
+        if(this.board != null)
+            board.getImages().remove(this);
+        this.board = board;
+        board.getImages().add(this);
+    }
 }

--- a/src/main/java/com/example/template/domain/board/entity/BoardLike.java
+++ b/src/main/java/com/example/template/domain/board/entity/BoardLike.java
@@ -23,4 +23,13 @@ public class BoardLike {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "board_id")
     private Board board;
+
+    // 연관관계 편의 메서드들
+    public void setMember(Member member) {
+        this.member = member;
+    }
+
+    public void setBoard(Board board) {
+        this.board = board;
+    }
 }

--- a/src/main/java/com/example/template/domain/board/entity/Comment.java
+++ b/src/main/java/com/example/template/domain/board/entity/Comment.java
@@ -27,8 +27,8 @@ public class Comment extends BaseEntity {
     @Column(name = "is_secret", nullable = false)
     private boolean isSecret;  // 비밀 여부
 
-    @Column(name = "is_author", nullable = false)
-    private boolean isAuthor;  // 글쓴이 인지 여부
+    // is_author 필드 제거
+    // TODO : "글쓴이"와 같은 유저인지는 동적인 정보이므로, 계산 로직으로 처리
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -45,4 +45,50 @@ public class Comment extends BaseEntity {
 
     @OneToMany(mappedBy = "parent")
     private List<Comment> children = new ArrayList<>();
+
+    @OneToMany(mappedBy = "comment", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<CommentImg> images = new ArrayList<>();
+
+    // Setter 메서드들
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public void setSecret(boolean secret) {
+        isSecret = secret;
+    }
+
+    // 연관관계 편의 메서드들
+    public void setMember(Member member) {
+        this.member = member;
+    }
+
+    public void setBoard(Board board) {
+        this.board = board;
+        board.getComments().add(this);
+    }
+
+    public void setParent(Comment parent) {
+        this.parent = parent;
+    }
+
+    public void addChild(Comment child) {
+        this.children.add(child);
+        child.setParent(this);
+    }
+
+    public void removeChild(Comment child) {
+        this.children.remove(child);
+        child.setParent(null);
+    }
+
+    public void addCommentImg(CommentImg commentImg) {
+        this.images.add(commentImg);
+        commentImg.setComment(this);
+    }
+
+    public void removeCommentImg(CommentImg commentImg) {
+        this.images.remove(commentImg);
+        commentImg.setComment(null);
+    }
 }

--- a/src/main/java/com/example/template/domain/board/entity/CommentImg.java
+++ b/src/main/java/com/example/template/domain/board/entity/CommentImg.java
@@ -21,4 +21,14 @@ public class CommentImg {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "comment_id")
     private Comment comment;
+
+    // Setter 메서드
+    public void setCommentImgUrl(String commentImgUrl) {
+        this.commentImgUrl = commentImgUrl;
+    }
+
+    // 연관관계 편의 메서드
+    public void setComment(Comment comment) {
+        this.comment = comment;
+    }
 }

--- a/src/main/java/com/example/template/domain/board/entity/CommentImg.java
+++ b/src/main/java/com/example/template/domain/board/entity/CommentImg.java
@@ -8,17 +8,17 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
-public class BoardImg {
+public class CommentImg {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "board_img_id", nullable = false)
+    @Column(name = "comment_img_id", nullable = false)
     private Long id;
 
-    @Column(name = "board_img_url", nullable = false)
-    private String boardImgUrl;  // 사진 경로
+    @Column(name = "comment_img_url", nullable = false)
+    private String commentImgUrl;  // 사진 경로
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "board_id")
-    private Board board;
+    @JoinColumn(name = "comment_id")
+    private Comment comment;
 }

--- a/src/main/java/com/example/template/domain/board/entity/enums/Category.java
+++ b/src/main/java/com/example/template/domain/board/entity/enums/Category.java
@@ -1,4 +1,4 @@
-package com.example.template.domain.board.entity;
+package com.example.template.domain.board.entity.enums;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/example/template/domain/board/entity/enums/HelpStatus.java
+++ b/src/main/java/com/example/template/domain/board/entity/enums/HelpStatus.java
@@ -1,4 +1,4 @@
-package com.example.template.domain.board.entity;
+package com.example.template.domain.board.entity.enums;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/src/main/java/com/example/template/domain/board/exception/BoardErrorCode.java
+++ b/src/main/java/com/example/template/domain/board/exception/BoardErrorCode.java
@@ -1,0 +1,31 @@
+package com.example.template.domain.board.exception;
+
+import com.example.template.global.apiPayload.ApiResponse;
+import com.example.template.global.apiPayload.code.status.BaseErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum BoardErrorCode implements BaseErrorCode {
+
+    // BOARD ERROR 응답
+    BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD404", "게시글을 찾을 수 없습니다."),
+    UNAUTHORIZED_BOARD_ACCESS(HttpStatus.FORBIDDEN, "BOARD403", "게시글에 대한 권한이 없습니다."),
+    HELP_STATUS_UPDATE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "BOARD400", "도와줘요 카테고리의 게시글만 상태 변경이 가능합니다."),
+    ALREADY_LIKED(HttpStatus.BAD_REQUEST, "BOARD401", "이미 좋아요를 누른 게시글입니다."),
+    LIKE_NOT_FOUND(HttpStatus.BAD_REQUEST, "BOARD402", "좋아요를 누르지 않은 상태에서는 취소할 수 없습니다."),
+
+    // 사용자 에러
+    // TODO : 테스트용. 삭제 예정
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD406", "회원을 찾을 수 없습니다.");
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+
+    @Override
+    public ApiResponse<Void> getErrorResponse() {
+        return ApiResponse.onFailure(code, message);
+    }
+}

--- a/src/main/java/com/example/template/domain/board/exception/BoardException.java
+++ b/src/main/java/com/example/template/domain/board/exception/BoardException.java
@@ -1,0 +1,12 @@
+package com.example.template.domain.board.exception;
+
+import com.example.template.global.apiPayload.code.status.BaseErrorCode;
+import com.example.template.global.apiPayload.exception.GeneralException;
+import lombok.Getter;
+
+@Getter
+public class BoardException extends GeneralException {
+    public BoardException(BaseErrorCode errorCode) {
+        super(errorCode);
+    }
+}

--- a/src/main/java/com/example/template/domain/board/repository/BoardLikeRepository.java
+++ b/src/main/java/com/example/template/domain/board/repository/BoardLikeRepository.java
@@ -1,0 +1,15 @@
+package com.example.template.domain.board.repository;
+
+import com.example.template.domain.board.entity.Board;
+import com.example.template.domain.board.entity.BoardLike;
+import com.example.template.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface BoardLikeRepository extends JpaRepository<BoardLike, Long> {
+    boolean existsByMemberAndBoard(Member member, Board board);
+    Optional<BoardLike> findByMemberAndBoard(Member member, Board board);
+}

--- a/src/main/java/com/example/template/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/template/domain/board/repository/BoardRepository.java
@@ -1,0 +1,16 @@
+package com.example.template.domain.board.repository;
+
+import com.example.template.domain.board.entity.Board;
+import com.example.template.domain.board.entity.enums.Category;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface BoardRepository extends JpaRepository<Board, Long> {
+    List<Board> findByCategoryOrderByCreatedAtDesc(Category category);
+    List<Board> findByMemberIdOrderByCreatedAtDesc(Long memberId);
+    Optional<Board> findByIdAndMemberId(Long id, Long memberId);
+}

--- a/src/main/java/com/example/template/domain/board/repository/CommentRepository.java
+++ b/src/main/java/com/example/template/domain/board/repository/CommentRepository.java
@@ -1,0 +1,13 @@
+package com.example.template.domain.board.repository;
+
+import com.example.template.domain.board.entity.Comment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface CommentRepository extends JpaRepository<Comment, Long> {
+    List<Comment> findByBoardId(Long boardId);
+    void deleteByBoardId(Long boardId);
+}

--- a/src/main/java/com/example/template/domain/board/repository/MemberRepository.java
+++ b/src/main/java/com/example/template/domain/board/repository/MemberRepository.java
@@ -1,0 +1,10 @@
+package com.example.template.domain.board.repository;
+
+import com.example.template.domain.member.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+// TODO : 테스트 용. 삭제 예정
+@Repository
+public interface MemberRepository extends JpaRepository<Member, Long> {
+}

--- a/src/main/java/com/example/template/domain/board/service/commandService/BoardCommandService.java
+++ b/src/main/java/com/example/template/domain/board/service/commandService/BoardCommandService.java
@@ -1,0 +1,14 @@
+package com.example.template.domain.board.service.commandService;
+
+import com.example.template.domain.board.dto.request.BoardRequestDTO;
+import com.example.template.domain.board.dto.response.BoardResponseDTO;
+import com.example.template.domain.board.entity.enums.HelpStatus;
+
+public interface BoardCommandService {
+    BoardResponseDTO.BoardDTO createBoard(BoardRequestDTO.CreateBoardDTO createBoardDTO);
+    BoardResponseDTO.BoardDTO updateBoard(Long boardId, BoardRequestDTO.UpdateBoardDTO updateBoardDTO);
+    Long deleteBoard(Long boardId);
+    BoardResponseDTO.BoardStatusDTO updateBoardStatus(Long boardId, BoardRequestDTO.UpdateBoardStatusDTO updateBoardStatusDTO);
+    BoardResponseDTO.BoardLikeDTO addLike(Long boardId);
+    BoardResponseDTO.BoardLikeDTO removeLike(Long boardId);
+}

--- a/src/main/java/com/example/template/domain/board/service/commandService/BoardCommandServiceImpl.java
+++ b/src/main/java/com/example/template/domain/board/service/commandService/BoardCommandServiceImpl.java
@@ -1,0 +1,126 @@
+package com.example.template.domain.board.service.commandService;
+
+import com.example.template.domain.board.dto.request.BoardRequestDTO;
+import com.example.template.domain.board.dto.response.BoardResponseDTO;
+import com.example.template.domain.board.entity.Board;
+import com.example.template.domain.board.entity.BoardLike;
+import com.example.template.domain.board.entity.enums.Category;
+import com.example.template.domain.board.exception.BoardErrorCode;
+import com.example.template.domain.board.exception.BoardException;
+import com.example.template.domain.board.repository.BoardLikeRepository;
+import com.example.template.domain.board.repository.BoardRepository;
+import com.example.template.domain.board.repository.MemberRepository;
+import com.example.template.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class BoardCommandServiceImpl implements BoardCommandService {
+
+    private final BoardRepository boardRepository;
+    private final BoardLikeRepository boardLikeRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public BoardResponseDTO.BoardDTO createBoard(BoardRequestDTO.CreateBoardDTO createBoardDTO) {
+        Member member = getMockMember();
+        Board board = createBoardDTO.toEntity(member);
+        Board savedBoard = boardRepository.save(board);
+        return BoardResponseDTO.BoardDTO.from(savedBoard, member.getId());
+    }
+
+    @Override
+    public BoardResponseDTO.BoardDTO updateBoard(Long boardId, BoardRequestDTO.UpdateBoardDTO updateBoardDTO) {
+        Member member = getMockMember();
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new BoardException(BoardErrorCode.BOARD_NOT_FOUND));
+        validateBoardOwnership(board, member);
+        board.update(updateBoardDTO.getTitle(), updateBoardDTO.getContent(), updateBoardDTO.getCategory());
+        return BoardResponseDTO.BoardDTO.from(board, member.getId());
+    }
+
+    @Override
+    public Long deleteBoard(Long boardId) {
+        Member member = getMockMember();
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new BoardException(BoardErrorCode.BOARD_NOT_FOUND));
+        validateBoardOwnership(board, member);
+        boardRepository.delete(board);
+        return boardId;
+    }
+
+    @Override
+    public BoardResponseDTO.BoardStatusDTO updateBoardStatus(Long boardId, BoardRequestDTO.UpdateBoardStatusDTO updateBoardStatusDTO) {
+        Member member = getMockMember();
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new BoardException(BoardErrorCode.BOARD_NOT_FOUND));
+        if (board.getCategory() != Category.HELP) {
+            throw new BoardException(BoardErrorCode.HELP_STATUS_UPDATE_NOT_ALLOWED);
+        }
+        validateBoardOwnership(board, member);
+        board.updateHelpStatus(updateBoardStatusDTO.getHelpStatus());
+        return BoardResponseDTO.BoardStatusDTO.from(board);
+    }
+
+    // TODO : 나중에 트리거 적용 시 고민해야 될 로직
+    // 트리거 + 영속성 컨텍스트 생각하면 뺄지 안뺄지 고민해봐야할 듯
+    @Override
+    public BoardResponseDTO.BoardLikeDTO addLike(Long boardId) {
+        Member member = getMockMember();
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new BoardException(BoardErrorCode.BOARD_NOT_FOUND));
+
+        if (boardLikeRepository.existsByMemberAndBoard(member, board)) {
+            throw new BoardException(BoardErrorCode.ALREADY_LIKED);
+        }
+
+        BoardLike boardLike = BoardLike.builder()
+                .board(board)
+                .member(member)
+                .build();
+        boardLikeRepository.save(boardLike);
+
+        board.incrementLikeCount();
+        boardRepository.save(board);
+
+        return BoardResponseDTO.BoardLikeDTO.from(board, member.getId());
+    }
+
+    @Override
+    public BoardResponseDTO.BoardLikeDTO removeLike(Long boardId) {
+        Member member = getMockMember();
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new BoardException(BoardErrorCode.BOARD_NOT_FOUND));
+
+        BoardLike boardLike = boardLikeRepository.findByMemberAndBoard(member, board)
+                .orElseThrow(() -> new BoardException(BoardErrorCode.LIKE_NOT_FOUND));
+
+        boardLikeRepository.delete(boardLike);
+
+        board.decrementLikeCount();
+        boardRepository.save(board);
+
+        return BoardResponseDTO.BoardLikeDTO.from(board, member.getId());
+    }
+
+    // TODO : 멤버의 임시 목데이터
+    private Member getMockMember() {
+        return memberRepository.findById(1L)
+                .orElseThrow(() -> new BoardException(BoardErrorCode.MEMBER_NOT_FOUND));
+    }
+
+    /*
+    is_author을 Boolean 값으로 넘겨주어 프론트엔드에서 UI 레벨의 제어를 하지만
+    수정, 삭제 등의 민감한 정보를 보호하기 위해 백엔드에서 추가적인 권한 검증을 수행
+     */
+    private void validateBoardOwnership(Board board, Member currentMember) {
+        if (!board.getMember().getId().equals(currentMember.getId())) {
+            throw new BoardException(BoardErrorCode.UNAUTHORIZED_BOARD_ACCESS);
+        }
+    }
+}

--- a/src/main/java/com/example/template/domain/board/service/queryService/BoardQueryService.java
+++ b/src/main/java/com/example/template/domain/board/service/queryService/BoardQueryService.java
@@ -1,0 +1,8 @@
+package com.example.template.domain.board.service.queryService;
+
+import com.example.template.domain.board.dto.response.BoardResponseDTO;
+
+// BoardQueryService 인터페이스
+public interface BoardQueryService {
+    BoardResponseDTO.BoardDetailDTO getBoardDetail(Long boardId);
+}

--- a/src/main/java/com/example/template/domain/board/service/queryService/BoardQueryServiceImpl.java
+++ b/src/main/java/com/example/template/domain/board/service/queryService/BoardQueryServiceImpl.java
@@ -1,0 +1,41 @@
+package com.example.template.domain.board.service.queryService;
+
+import com.example.template.domain.board.dto.response.BoardResponseDTO;
+import com.example.template.domain.board.entity.Board;
+import com.example.template.domain.board.entity.Comment;
+import com.example.template.domain.board.exception.BoardErrorCode;
+import com.example.template.domain.board.exception.BoardException;
+import com.example.template.domain.board.repository.BoardRepository;
+import com.example.template.domain.board.repository.CommentRepository;
+import com.example.template.domain.board.repository.MemberRepository;
+import com.example.template.domain.member.entity.Member;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class BoardQueryServiceImpl implements BoardQueryService {
+
+    private final BoardRepository boardRepository;
+    private final CommentRepository commentRepository;
+    private final MemberRepository memberRepository;
+
+    @Override
+    public BoardResponseDTO.BoardDetailDTO getBoardDetail(Long boardId) {
+        Member member = getMockMember();
+        Board board = boardRepository.findById(boardId)
+                .orElseThrow(() -> new BoardException(BoardErrorCode.BOARD_NOT_FOUND));
+        List<Comment> comments = commentRepository.findByBoardId(boardId);
+        return BoardResponseDTO.BoardDetailDTO.of(board, comments, member.getId());
+    }
+
+    // TODO : 멤버의 임시 목데이터
+    private Member getMockMember() {
+        return memberRepository.findById(2L)
+                .orElseThrow(() -> new BoardException(BoardErrorCode.MEMBER_NOT_FOUND));
+    }
+}

--- a/src/test/java/com/example/template/FillEnergyApplicationTests.java
+++ b/src/test/java/com/example/template/FillEnergyApplicationTests.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 
 @SpringBootTest
-class SmupoolApplicationTests {
+class FillEnergyApplicationTests {
 
 	@Test
 	void contextLoads() {


### PR DESCRIPTION
## ☝️Issue Number
- resolve #14 

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 📌 개요
- 게시글 CRUD API 구현 (#14)

## 🔎 Key Changes
- [✨ feat: CommentImg 엔티티 추가](https://github.com/Fill-ENERGY/BackEnd_Server/commit/f41d1c104c722df8a5ce7c1cd57573a71762daac)
- [♻️ refactor: 각 엔티티에 Setter 및 연관관계 편의 메서드 추가](https://github.com/Fill-ENERGY/BackEnd_Server/commit/76948e777e0655b39a23ee4948d7b691d3593d16)
- [✨ feat: Repository 추가](https://github.com/Fill-ENERGY/BackEnd_Server/commit/37f2c8d5154b3d7c80d8265420547bc6468baac4)
- [♻️ refactor: BoardErrorCode 에러 코드 추가](https://github.com/Fill-ENERGY/BackEnd_Server/commit/672d7399b9ca2e7bacda97bdadc419cedbda7449)
- [✨ feat: 게시글 CRUD API 구현](https://github.com/Fill-ENERGY/BackEnd_Server/commit/1585f068eb155a05eb8b8648ea1ffec46df5dab3)
**> 해당 Commit 만 봐주시면 될 것 같습니다.**

- 아래는 사소한 수정 사항입니다.
- [♻️ refactor: 어플리케이션 이름 변경](https://github.com/Fill-ENERGY/BackEnd_Server/commit/9b0fda5cc96a315926dc6d56c829aeac0aa73207)

## 💌 To Reviewers
- 현재 Security 의존성 주석 처리해야 Run 돌아갑니다.
- 포스트맨 / 스웨거 통해서 모든 케이스 테스트 완료 했습니다.
- 현재, 사용자는 MockData (더미데이터) 넣어서 테스트 했습니다.
~~~
   private Member getMockMember() {
        return memberRepository.findById(1L)
                .orElseThrow(() -> new BoardException(BoardErrorCode.MEMBER_NOT_FOUND));
    }
~~~
-  Comment에서 is_author 필드를 제거했습니다.
    // TODO : "글쓴이"와 같은 유저인지는 동적인 정보이므로, 계산 로직으로 처리
-  좋아요 기능 은 트리거 + 영속성 컨텍스트 생각하면 뺄지 안뺄지 고민해봐야 할 것 같습니다.

## ~ 이번 주(8/4) 까지
- 커서 적용하여 목록 조회 로직 완성 (커서 좀 더 깊게 공부 중이라 하루 이틀 더 걸릴 것 같습니다.)
- 내 게시글 조회 ( 디자인이 아직 다 나오지 않아, 보류 상황입니다. )
- 댓글 CRUD

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
