### PR TITLE
♻️ refactor: 게시글 목록 조회 & 이미지 API (#38)

### DIFF
--- a/src/main/java/com/example/template/domain/board/dto/request/BoardRequestDTO.java
+++ b/src/main/java/com/example/template/domain/board/dto/request/BoardRequestDTO.java
@@ -30,7 +30,8 @@ public class BoardRequestDTO {
 
         public Board toEntity(Member member) {
             HelpStatus helpStatus = this.category == Category.HELP ? HelpStatus.REQUESTED : HelpStatus.NONE;
-            Board board = Board.builder()
+
+            return Board.builder()
                     .title(title)
                     .content(content)
                     .category(category)
@@ -40,17 +41,6 @@ public class BoardRequestDTO {
                     .commentCount(0)
                     .images(new ArrayList<>())
                     .build();
-
-            // images가 null이 아닌 경우 처리
-            if (images != null) {
-                for (String imageUrl : images) {
-                    BoardImg boardImg = BoardImg.builder()
-                            .boardImgUrl(imageUrl)
-                            .build();
-                    boardImg.setBoard(board);
-                }
-            }
-            return board;
         }
     }
 

--- a/src/main/java/com/example/template/domain/board/dto/response/BoardResponseDTO.java
+++ b/src/main/java/com/example/template/domain/board/dto/response/BoardResponseDTO.java
@@ -12,7 +12,15 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public class BoardResponseDTO {
+
     @Getter
+    @Builder
+    public static class BoardImgDTO {
+        private List<String> images;
+    }
+
+
+        @Getter
     @Builder
     public static class BoardDTO {
         private Long id;

--- a/src/main/java/com/example/template/domain/board/entity/Board.java
+++ b/src/main/java/com/example/template/domain/board/entity/Board.java
@@ -47,7 +47,7 @@ public class Board extends BaseEntity {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "board", cascade = CascadeType.ALL)
     private List<BoardImg> images = new ArrayList<>();
 
     @OneToMany(mappedBy = "board", cascade = CascadeType.ALL, orphanRemoval = true)

--- a/src/main/java/com/example/template/domain/board/entity/BoardImg.java
+++ b/src/main/java/com/example/template/domain/board/entity/BoardImg.java
@@ -1,5 +1,6 @@
 package com.example.template.domain.board.entity;
 
+import com.example.template.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -8,7 +9,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Entity
-public class BoardImg {
+public class BoardImg extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)

--- a/src/main/java/com/example/template/domain/board/entity/enums/SortType.java
+++ b/src/main/java/com/example/template/domain/board/entity/enums/SortType.java
@@ -1,0 +1,6 @@
+package com.example.template.domain.board.entity.enums;
+
+public enum SortType {
+    LIKES,
+    LATEST
+}

--- a/src/main/java/com/example/template/domain/board/exception/BoardErrorCode.java
+++ b/src/main/java/com/example/template/domain/board/exception/BoardErrorCode.java
@@ -10,7 +10,7 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum BoardErrorCode implements BaseErrorCode {
 
-    // BOARD ERROR 응답
+    // BOARD 에러
     BOARD_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD404", "게시글을 찾을 수 없습니다."),
     UNAUTHORIZED_BOARD_ACCESS(HttpStatus.FORBIDDEN, "BOARD403", "게시글에 대한 권한이 없습니다."),
     HELP_STATUS_UPDATE_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "BOARD400", "도와줘요 카테고리의 게시글만 상태 변경이 가능합니다."),
@@ -19,7 +19,11 @@ public enum BoardErrorCode implements BaseErrorCode {
 
     // 사용자 에러
     // TODO : 테스트용. 삭제 예정
-    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD406", "회원을 찾을 수 없습니다.");
+    MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "BOARD406", "회원을 찾을 수 없습니다."),
+
+    // BOARD IMAGE 에러
+    INVALID_IMAGE_URLS(HttpStatus.BAD_REQUEST, "BOARD400", "일부 이미지 URL이 유효하지 않거나 찾을 수 없습니다.");
+
     private final HttpStatus httpStatus;
     private final String code;
     private final String message;

--- a/src/main/java/com/example/template/domain/board/repository/BoardImgRepository.java
+++ b/src/main/java/com/example/template/domain/board/repository/BoardImgRepository.java
@@ -1,0 +1,17 @@
+package com.example.template.domain.board.repository;
+
+import com.example.template.domain.board.entity.BoardImg;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Repository
+public interface BoardImgRepository extends JpaRepository<BoardImg, Long> {
+    List<BoardImg> findAllByBoardImgUrlIn(List<String> imageUrls);
+    @Query("SELECT b FROM BoardImg b WHERE b.board IS NULL")
+    List<BoardImg> findUnmappedImages();
+}

--- a/src/main/java/com/example/template/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/template/domain/board/repository/BoardRepository.java
@@ -1,16 +1,45 @@
 package com.example.template.domain.board.repository;
 
+
 import com.example.template.domain.board.entity.Board;
 import com.example.template.domain.board.entity.enums.Category;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
-import java.util.Optional;
 
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
-    List<Board> findByCategoryOrderByCreatedAtDesc(Category category);
-    List<Board> findByMemberIdOrderByCreatedAtDesc(Long memberId);
-    Optional<Board> findByIdAndMemberId(Long id, Long memberId);
+    @Query("SELECT b FROM Board b WHERE b.id < :cursor ORDER BY b.likeNum DESC, b.id DESC")
+    List<Board> findAllOrderByLikesWithCursor(@Param("cursor") Long cursor, Pageable pageable);
+
+    @Query("SELECT b FROM Board b WHERE b.id < :cursor ORDER BY b.id DESC")
+    List<Board> findAllOrderByLatestWithCursor(@Param("cursor") Long cursor, Pageable pageable);
+
+    @Query("SELECT b FROM Board b WHERE b.category = :category AND b.id < :cursor ORDER BY b.likeNum DESC, b.id DESC")
+    List<Board> findByCategoryOrderByLikesWithCursor(@Param("category") Category category, @Param("cursor") Long cursor, Pageable pageable);
+
+    @Query("SELECT b FROM Board b WHERE b.category = :category AND b.id < :cursor ORDER BY b.id DESC")
+    List<Board> findByCategoryOrderByLatestWithCursor(@Param("category") Category category, @Param("cursor") Long cursor, Pageable pageable);
+
+    default List<Board> findAllOrderByLikesWithCursor(Long cursor, Integer limit) {
+        return findAllOrderByLikesWithCursor(cursor, PageRequest.of(0, limit));
+    }
+
+    default List<Board> findAllOrderByLatestWithCursor(Long cursor, Integer limit) {
+        return findAllOrderByLatestWithCursor(cursor, PageRequest.of(0, limit));
+    }
+
+    default List<Board> findByCategoryOrderByLikesWithCursor(Category category, Long cursor, Integer limit) {
+        return findByCategoryOrderByLikesWithCursor(category, cursor, PageRequest.of(0, limit));
+    }
+
+    default List<Board> findByCategoryOrderByLatestWithCursor(Category category, Long cursor, Integer limit) {
+        return findByCategoryOrderByLatestWithCursor(category, cursor, PageRequest.of(0, limit));
+    }
 }
+

--- a/src/main/java/com/example/template/domain/board/scheduler/UnmappedImageCleanupScheduler.java
+++ b/src/main/java/com/example/template/domain/board/scheduler/UnmappedImageCleanupScheduler.java
@@ -1,0 +1,39 @@
+package com.example.template.domain.board.scheduler;
+
+import com.example.template.domain.board.entity.BoardImg;
+import com.example.template.domain.board.repository.BoardImgRepository;
+import com.example.template.global.config.aws.S3Manager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class UnmappedImageCleanupScheduler {
+
+    private final BoardImgRepository boardImgRepository;
+    private final S3Manager s3Manager;
+
+    @Scheduled(cron = "0 0 3 * * ?") // 매일 새벽 3시에 실행
+    @Transactional
+    public void cleanupUnmappedImages() {
+        List<BoardImg> unmappedImages = boardImgRepository.findUnmappedImages();
+
+        for (BoardImg image : unmappedImages) {
+            s3Manager.deleteFile(image.getBoardImgUrl());
+            boardImgRepository.delete(image);
+        }
+
+        log.info("[cleanupUnmappedImages 실행] 삭제완료");
+    }
+
+    // TODO: 테스트용 수동 트리거 메서드 - 삭제 예정
+    public void manualCleanup() {
+        this.cleanupUnmappedImages();
+    }
+}

--- a/src/main/java/com/example/template/domain/board/service/commandService/BoardCommandService.java
+++ b/src/main/java/com/example/template/domain/board/service/commandService/BoardCommandService.java
@@ -3,8 +3,12 @@ package com.example.template.domain.board.service.commandService;
 import com.example.template.domain.board.dto.request.BoardRequestDTO;
 import com.example.template.domain.board.dto.response.BoardResponseDTO;
 import com.example.template.domain.board.entity.enums.HelpStatus;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 public interface BoardCommandService {
+    BoardResponseDTO.BoardImgDTO uploadImages(List<MultipartFile> images);
     BoardResponseDTO.BoardDTO createBoard(BoardRequestDTO.CreateBoardDTO createBoardDTO);
     BoardResponseDTO.BoardDTO updateBoard(Long boardId, BoardRequestDTO.UpdateBoardDTO updateBoardDTO);
     Long deleteBoard(Long boardId);

--- a/src/main/java/com/example/template/domain/board/service/queryService/BoardQueryService.java
+++ b/src/main/java/com/example/template/domain/board/service/queryService/BoardQueryService.java
@@ -1,8 +1,12 @@
 package com.example.template.domain.board.service.queryService;
 
 import com.example.template.domain.board.dto.response.BoardResponseDTO;
+import com.example.template.domain.board.entity.enums.Category;
+import com.example.template.domain.board.entity.enums.SortType;
 
 // BoardQueryService 인터페이스
 public interface BoardQueryService {
+    BoardResponseDTO.BoardListDTO getBoardList(Category category, Long cursor, Integer limit, SortType sortType);
+
     BoardResponseDTO.BoardDetailDTO getBoardDetail(Long boardId);
 }

--- a/src/main/java/com/example/template/domain/board/service/queryService/BoardQueryServiceImpl.java
+++ b/src/main/java/com/example/template/domain/board/service/queryService/BoardQueryServiceImpl.java
@@ -3,6 +3,8 @@ package com.example.template.domain.board.service.queryService;
 import com.example.template.domain.board.dto.response.BoardResponseDTO;
 import com.example.template.domain.board.entity.Board;
 import com.example.template.domain.board.entity.Comment;
+import com.example.template.domain.board.entity.enums.Category;
+import com.example.template.domain.board.entity.enums.SortType;
 import com.example.template.domain.board.exception.BoardErrorCode;
 import com.example.template.domain.board.exception.BoardException;
 import com.example.template.domain.board.repository.BoardRepository;
@@ -25,6 +27,36 @@ public class BoardQueryServiceImpl implements BoardQueryService {
     private final MemberRepository memberRepository;
 
     @Override
+    public BoardResponseDTO.BoardListDTO getBoardList(Category category, Long cursor, Integer limit, SortType sortType) {
+
+        Member member = getMockMember();
+
+        // 첫 페이지 로딩 시 매우 큰 ID 값 사용
+        if (cursor == 0) {
+            cursor = Long.MAX_VALUE;
+        }
+
+        List<Board> boards;
+        // 전체 조회
+        if (category == null) {
+            boards = sortType == SortType.LIKES
+                    ? boardRepository.findAllOrderByLikesWithCursor(cursor, limit)
+                    : boardRepository.findAllOrderByLatestWithCursor(cursor, limit);
+        }
+        // 카테고리별 조회
+        else {
+            boards = sortType == SortType.LIKES
+                    ? boardRepository.findByCategoryOrderByLikesWithCursor(category, cursor, limit)
+                    : boardRepository.findByCategoryOrderByLatestWithCursor(category, cursor, limit);
+        }
+
+        Long nextCursor = boards.isEmpty() ? null : boards.get(boards.size() - 1).getId();
+        boolean hasNext = boards.size() == limit;
+
+        return BoardResponseDTO.BoardListDTO.of(boards, nextCursor, hasNext, member.getId());
+    }
+
+    @Override
     public BoardResponseDTO.BoardDetailDTO getBoardDetail(Long boardId) {
         Member member = getMockMember();
         Board board = boardRepository.findById(boardId)
@@ -35,7 +67,7 @@ public class BoardQueryServiceImpl implements BoardQueryService {
 
     // TODO : 멤버의 임시 목데이터
     private Member getMockMember() {
-        return memberRepository.findById(2L)
+        return memberRepository.findById(1L)
                 .orElseThrow(() -> new BoardException(BoardErrorCode.MEMBER_NOT_FOUND));
     }
 }


### PR DESCRIPTION
## ☝️Issue Number
- resolve #38 

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 📌 개요
- ♻️ refactor: 게시글 목록 조회 & 이미지 API (#38)

## 🔎 Key Changes
- 46c2a23e75391943f9c0f5045d2533b9a45ca7af

## 💌 To Reviewers
---
- 커서 기반 페이지네이션 적용하여 무한스크롤에 용이 하도록, Search 로직 구현했습니다.
- 이미지 API 와 게시글 작성 / 수정 / 삭제 API 분리했습니다.
---
- 작성의 경우 이미지 선택시 1차로 이미지 API가 호출이 되고,
- 게시글 작성 완료를 누르면 2차로 "제목, 내용 등"의 DTO 만 따로 처리한 뒤에, BoardImg을 Board와 매핑만 해줍니다.
- 정상적이지 않은 Flow (이미지만 선택하고 게시글을 작성하지 않고 끄는 경우)를 고려하여,
   스케쥴러를 사용하여, 주기적으로 매핑되지 않은 이미지를 db와 s3을 삭제시킵니다.
---
- 수정의 경우도
- 새로 이미지를 등록할 경우, 이미지 api 를 1차적으로 들리고 옵니다.
- 코드 상에서는 기존 img와 비교합니다.
   변경사항이 없으면 이미지 관련 처리는 건너 뜁니다.
   삭제된 이미지는 삭제시켜주고, 새로 등록된 이미지는 작성과 마찬가지로 매핑만 시켜줍니다.
---
- 삭제 알고리즘도 삭제 매핑만 끊어주거나 (스케쥴러가 나중에 몰아서 처리), 즉시 삭제하는 방식 중에 고민해보았는데,
삭제는 업로드만큼 s3 부담이 가는 작업이 아니고, 오히려 스케쥴러의 부담이 커질 것 같아서, 즉시 처리해주었습니다.
---
### 목/금까지 댓글도 올리겠습니다.

## 📸 스크린샷
- 선택사항 입니다.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
