### PR TITLE
✨ [FEAT] 현재 로그인하여 인증된 Member 어노테이션으로 가져오기 구현 (#44)

### DIFF
--- a/src/main/java/com/example/template/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/template/domain/member/controller/MemberController.java
@@ -2,9 +2,11 @@ package com.example.template.domain.member.controller;
 
 import com.example.template.domain.member.dto.MemberRequestDTO;
 import com.example.template.domain.member.dto.MemberResponseDTO;
+import com.example.template.domain.member.entity.Member;
 import com.example.template.domain.member.jwt.dto.JwtDTO;
 import com.example.template.domain.member.jwt.util.JwtProvider;
 import com.example.template.domain.member.service.MemberService;
+import com.example.template.global.annotation.AuthenticatedMember;
 import com.example.template.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -48,5 +50,14 @@ public class MemberController {
     public ApiResponse<JwtDTO> reissueToken(@RequestHeader("RefreshToken") String refreshToken) {
         return ApiResponse.onSuccess(memberService.reissueToken(refreshToken));
     }
+    @Operation(summary = "인증 테스트 용", description = "어노테이션 작동 테스트용 API 입니다.")
+    @GetMapping("/me")
+    public ApiResponse<MemberResponseDTO.MemberTestDTO> getCurrentMember(@AuthenticatedMember Member member) {
+        MemberResponseDTO.MemberTestDTO memberDTO = new MemberResponseDTO.MemberTestDTO(
+                member.getId(),
+                member.getEmail(),
+                member.getName()
+        );
+        return ApiResponse.onSuccess(memberDTO);}
 
 }

--- a/src/main/java/com/example/template/domain/member/dto/MemberResponseDTO.java
+++ b/src/main/java/com/example/template/domain/member/dto/MemberResponseDTO.java
@@ -45,5 +45,14 @@ public class MemberResponseDTO {
                     .build();
         }
     }
+    @Getter
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @Builder
+    public static class MemberTestDTO {
+        private Long id;
+        private String email;
+        private String name;
 
+    }
 }

--- a/src/main/java/com/example/template/domain/member/service/MemberQueryService.java
+++ b/src/main/java/com/example/template/domain/member/service/MemberQueryService.java
@@ -1,9 +1,11 @@
 package com.example.template.domain.member.service;
 
 import com.example.template.domain.member.dto.ProfileResponseDTO;
+import com.example.template.domain.member.entity.Member;
 
 public interface MemberQueryService {
 
     ProfileResponseDTO.ProfileDTO getProfile(Long memberId);
+    Member getMemberByEmail(String email);
 
 }

--- a/src/main/java/com/example/template/domain/member/service/MemberQueryServiceImpl.java
+++ b/src/main/java/com/example/template/domain/member/service/MemberQueryServiceImpl.java
@@ -3,6 +3,8 @@ package com.example.template.domain.member.service;
 import com.example.template.domain.func1.exception.FuncException;
 import com.example.template.domain.member.dto.ProfileResponseDTO;
 import com.example.template.domain.member.entity.Member;
+import com.example.template.domain.member.exception.MemberErrorCode;
+import com.example.template.domain.member.exception.MemberException;
 import com.example.template.domain.member.repository.MemberRepository;
 import com.example.template.global.apiPayload.code.GeneralErrorCode;
 import lombok.AllArgsConstructor;
@@ -20,5 +22,10 @@ public class MemberQueryServiceImpl implements MemberQueryService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new FuncException(GeneralErrorCode.NOT_FOUND_404));
         return ProfileResponseDTO.from(member);
+    }
+
+    @Override
+    public Member getMemberByEmail(String email) {
+        return memberRepository.findByEmail(email).orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
     }
 }

--- a/src/main/java/com/example/template/global/annotation/AuthenticatedMember.java
+++ b/src/main/java/com/example/template/global/annotation/AuthenticatedMember.java
@@ -1,0 +1,14 @@
+package com.example.template.global.annotation;
+
+import io.swagger.v3.oas.annotations.Parameter;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+@Parameter(hidden = true)
+public @interface AuthenticatedMember {
+}

--- a/src/main/java/com/example/template/global/annotation/AuthenticatedMemberArgumentResolver.java
+++ b/src/main/java/com/example/template/global/annotation/AuthenticatedMemberArgumentResolver.java
@@ -1,0 +1,36 @@
+package com.example.template.global.annotation;
+
+import com.example.template.domain.member.entity.Member;
+import com.example.template.domain.member.jwt.userdetails.PrincipalDetails;
+import com.example.template.domain.member.service.MemberQueryService;
+import com.example.template.domain.member.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+@Component
+@RequiredArgsConstructor
+@Transactional
+public class AuthenticatedMemberArgumentResolver implements HandlerMethodArgumentResolver {
+
+    private final MemberQueryService memberQueryService;
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        boolean parameterAnnotation = parameter.hasParameterAnnotation(AuthenticatedMember.class);
+        boolean memberParameterType = parameter.getParameterType().isAssignableFrom(Member.class);
+        return parameterAnnotation && memberParameterType;
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer, NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        Object userDetails = SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        Member member = memberQueryService.getMemberByEmail(((PrincipalDetails)userDetails).getUsername());
+        return member;
+    }
+}

--- a/src/main/java/com/example/template/global/config/WebConfig.java
+++ b/src/main/java/com/example/template/global/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.example.template.global.config;
+
+import com.example.template.global.annotation.AuthenticatedMemberArgumentResolver;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.List;
+
+@Configuration
+@RequiredArgsConstructor
+public class WebConfig implements WebMvcConfigurer {
+
+    private final AuthenticatedMemberArgumentResolver authenticatedMemberArgumentResolver;
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
+        resolvers.add(authenticatedMemberArgumentResolver);
+    }
+}


### PR DESCRIPTION
## ☝️Issue Number
- resolve #44 

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 📌 개요
- 로그인 유저를 가져오는 어노테이션 생성
- 테스트 용 API 추가 구현

## 🔎 Key Changes
- [✨ feat: 현재 로그인된 멤버를 가져오는 어노테이션 구현](https://github.com/Fill-ENERGY/BackEnd_Server/pull/45/commits/99865be5230abff60c222e2425b54931bfcc43d0)
- [✨ feat: 어노테이션 적용 테스트 API 구현](https://github.com/Fill-ENERGY/BackEnd_Server/pull/45/commits/5bcfab5980b6dc41d1f6304336d1a40083391f94)

## 💌 To Reviewers
- @AuthenticatedMember 어노테이션을 구현하여 현재 로그인된 Member를 가져올 수 있도록 하였습니다.
- 각자 필요한 부분에 활용하시면 될 것 같습니다.

## 📸 스크린샷
- 선택사항 입니다.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
