### PR TITLE
♻️ refactor: 쪽지 로직 변경 (#32)

### DIFF
--- a/src/main/java/com/example/template/domain/message/controller/MessageController.java
+++ b/src/main/java/com/example/template/domain/message/controller/MessageController.java
@@ -51,6 +51,14 @@ public class MessageController {
         return ApiResponse.onSuccess(messageListDTO);
     }
 
+    @GetMapping("/threads/members/{memberId}")
+    @Operation(summary = "채팅방 조회 API (커뮤니티 > 채팅하기)", description = "게시글 작성자의 id를 전달해주세요.\n\n" +
+            "커뮤니티에서 채팅하기를 클릭하는 경우, 게시글 작성자와의 채팅방이 존재하는지 조회합니다.\n\n" + "존재하면 채팅방 id를, 존재하지 않으면 null을 반환합니다.")
+    public ApiResponse<MessageResponseDTO.ThreadDTO> getThread(@PathVariable("memberId") Long writerId) {
+        MessageResponseDTO.ThreadDTO threadDTO = messageQueryService.getThread(writerId);
+        return ApiResponse.onSuccess(threadDTO);
+    }
+
     @GetMapping("/threads")
     @Operation(summary = "채팅방 목록 조회 API")
     public ApiResponse<List<MessageResponseDTO.ThreadListDTO>> getThreadList() {

--- a/src/main/java/com/example/template/domain/message/controller/MessageController.java
+++ b/src/main/java/com/example/template/domain/message/controller/MessageController.java
@@ -8,7 +8,9 @@ import com.example.template.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 
@@ -20,10 +22,11 @@ public class MessageController {
     private final MessageCommandService messageCommandService;
     private final MessageQueryService messageQueryService;
 
-    @PostMapping("/messages")
+    @PostMapping(value = "/messages", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary = "쪽지 생성 API")
-    public ApiResponse<MessageResponseDTO.MessageDTO> createMessage(@Valid @RequestBody MessageRequestDTO.CreateMessageDTO requestDTO) {
-        MessageResponseDTO.MessageDTO messageDTO = messageCommandService.createMessage(requestDTO);
+    public ApiResponse<MessageResponseDTO.MessageDTO> createMessage(@RequestPart(value = "file", required = false) List<MultipartFile> files,
+                                                                    @Valid @RequestPart("requestDTO") MessageRequestDTO.CreateMessageDTO requestDTO) {
+        MessageResponseDTO.MessageDTO messageDTO = messageCommandService.createMessage(files, requestDTO);
         return ApiResponse.onSuccess(messageDTO);
     }
 

--- a/src/main/java/com/example/template/domain/message/dto/request/MessageRequestDTO.java
+++ b/src/main/java/com/example/template/domain/message/dto/request/MessageRequestDTO.java
@@ -3,7 +3,7 @@ package com.example.template.domain.message.dto.request;
 import com.example.template.domain.member.entity.Member;
 import com.example.template.domain.message.entity.Message;
 import com.example.template.domain.message.entity.MessageThread;
-import com.example.template.domain.message.entity.ReadStatus;
+import com.example.template.domain.message.entity.enums.ReadStatus;
 import jakarta.validation.constraints.NotNull;
 import lombok.Getter;
 
@@ -11,16 +11,15 @@ public class MessageRequestDTO {
 
     @Getter
     public static class CreateMessageDTO {
-        Long threadId;
-        String content;
-        String imgUrl;
+        private Long threadId;
+        private String content;
         @NotNull(message = "받는 사람 id는 필수입니다.")
-        Long receiverId;
+        private Long receiverId;
 
-        public Message toEntity(Member sender, Member receiver, MessageThread messageThread) {
+        public Message toEntity(Member sender, Member receiver, String imgUrl, MessageThread messageThread) {
             return Message.builder()
                     .content(content)
-                    .imgUrl(imgUrl)
+//                    .imgUrl(imgUrl)
                     .readStatus(ReadStatus.NOT_READ)
                     .deletedBySen(false)
                     .deletedByRec(false)

--- a/src/main/java/com/example/template/domain/message/dto/request/MessageRequestDTO.java
+++ b/src/main/java/com/example/template/domain/message/dto/request/MessageRequestDTO.java
@@ -16,10 +16,9 @@ public class MessageRequestDTO {
         @NotNull(message = "받는 사람 id는 필수입니다.")
         private Long receiverId;
 
-        public Message toEntity(Member sender, Member receiver, String imgUrl, MessageThread messageThread) {
+        public Message toEntity(Member sender, Member receiver, MessageThread messageThread) {
             return Message.builder()
                     .content(content)
-//                    .imgUrl(imgUrl)
                     .readStatus(ReadStatus.NOT_READ)
                     .deletedBySen(false)
                     .deletedByRec(false)

--- a/src/main/java/com/example/template/domain/message/dto/response/MessageResponseDTO.java
+++ b/src/main/java/com/example/template/domain/message/dto/response/MessageResponseDTO.java
@@ -153,4 +153,17 @@ public class MessageResponseDTO {
         }
     }
 
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class ThreadDTO {
+        private Long threadId;
+
+        public static ThreadDTO from(MessageThread thread) {
+            return ThreadDTO.builder()
+                    .threadId(thread.getId())
+                    .build();
+        }
+    }
 }

--- a/src/main/java/com/example/template/domain/message/dto/response/MessageResponseDTO.java
+++ b/src/main/java/com/example/template/domain/message/dto/response/MessageResponseDTO.java
@@ -71,7 +71,6 @@ public class MessageResponseDTO {
         private Long memberId;
         private String status;
         private LocalDateTime leftAt;
-        private Long lastViewedMessageId;
 
         public static ThreadDeleteDTO from(MessageParticipant participant) {
             return ThreadDeleteDTO.builder()
@@ -79,7 +78,6 @@ public class MessageResponseDTO {
                     .memberId(participant.getMember().getId())
                     .status(participant.getParticipationStatus().name())
                     .leftAt(participant.getLeftAt())
-                    .lastViewedMessageId(participant.getLastViewedMessage())
                     .build();
         }
     }

--- a/src/main/java/com/example/template/domain/message/dto/response/MessageResponseDTO.java
+++ b/src/main/java/com/example/template/domain/message/dto/response/MessageResponseDTO.java
@@ -116,14 +116,12 @@ public class MessageResponseDTO {
     public static class RecentMessage {
         private Long messageId;
         private String content;
-//        private String imgUrl;
         private LocalDateTime createdAt;
 
         public static RecentMessage from(Message message) {
             return RecentMessage.builder()
                     .messageId(message.getId())
-                    .content(message.getContent())
-//                    .imgUrl(message.getImgUrl())
+                    .content(message.getContent() == null || message.getContent().isEmpty() ? "사진을 전송했습니다." : message.getContent())
                     .createdAt(message.getCreatedAt())
                     .build();
         }

--- a/src/main/java/com/example/template/domain/message/dto/response/MessageResponseDTO.java
+++ b/src/main/java/com/example/template/domain/message/dto/response/MessageResponseDTO.java
@@ -2,6 +2,7 @@ package com.example.template.domain.message.dto.response;
 
 import com.example.template.domain.member.entity.Member;
 import com.example.template.domain.message.entity.Message;
+import com.example.template.domain.message.entity.MessageImg;
 import com.example.template.domain.message.entity.MessageParticipant;
 import com.example.template.domain.message.entity.MessageThread;
 import lombok.AllArgsConstructor;
@@ -20,19 +21,19 @@ public class MessageResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MessageDTO {
-        Long messageId;
-        String content;
-        String imgUrl;
-        Long sender;
-        Long receiver;
-        String readStatus;
-        LocalDateTime createdAt;
+        private Long messageId;
+        private String content;
+        private List<String> images;
+        private Long sender;
+        private Long receiver;
+        private String readStatus;
+        private LocalDateTime createdAt;
 
         public static MessageDTO from(Message message) {
             return MessageDTO.builder()
                     .messageId(message.getId())
                     .content(message.getContent())
-                    .imgUrl(message.getImgUrl())
+                    .images(message.getImages().stream().map(MessageImg::getImgUrl).toList())
                     .sender(message.getSender().getId())
                     .receiver(message.getReceiver().getId())
                     .readStatus(message.getReadStatus().name())
@@ -46,10 +47,10 @@ public class MessageResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MessageDeleteDTO {
-        Long messageId;
-        boolean deletedBySender;
-        boolean deletedByReceiver;
-        LocalDateTime updatedAt;
+        private Long messageId;
+        private boolean deletedBySender;
+        private boolean deletedByReceiver;
+        private LocalDateTime updatedAt;
 
         public static MessageDeleteDTO from(Message message) {
             return MessageDeleteDTO.builder()
@@ -66,11 +67,11 @@ public class MessageResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ThreadDeleteDTO {
-        Long threadId;
-        Long memberId;
-        String status;
-        LocalDateTime leftAt;
-        Long lastViewedMessageId;
+        private Long threadId;
+        private Long memberId;
+        private String status;
+        private LocalDateTime leftAt;
+        private Long lastViewedMessageId;
 
         public static ThreadDeleteDTO from(MessageParticipant participant) {
             return ThreadDeleteDTO.builder()
@@ -88,12 +89,12 @@ public class MessageResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class ThreadListDTO {
-        Long threadId;
-        String name;
-        String email;
-        String profileImg;
-        RecentMessage recentMessage;
-        int unreadMessageCount;
+        private Long threadId;
+        private String name;
+        private String email;
+        private String profileImg;
+        private RecentMessage recentMessage;
+        private int unreadMessageCount;
 
         public static ThreadListDTO of(MessageParticipant participant, RecentMessage recentMessage,
                                        int unreadMessageCount, Member otherMember) {
@@ -113,16 +114,16 @@ public class MessageResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class RecentMessage {
-        Long messageId;
-        String content;
-        String imgUrl;
-        LocalDateTime createdAt;
+        private Long messageId;
+        private String content;
+//        private String imgUrl;
+        private LocalDateTime createdAt;
 
         public static RecentMessage from(Message message) {
             return RecentMessage.builder()
                     .messageId(message.getId())
                     .content(message.getContent())
-                    .imgUrl(message.getImgUrl())
+//                    .imgUrl(message.getImgUrl())
                     .createdAt(message.getCreatedAt())
                     .build();
         }
@@ -133,11 +134,11 @@ public class MessageResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class MessageListDTO {
-        Long threadId;
-        String name;
-        String email;
-        String profileImg;
-        List<MessageDTO> messages;
+        private Long threadId;
+        private String name;
+        private String email;
+        private String profileImg;
+        private List<MessageDTO> messages;
 
         public static MessageListDTO from(MessageThread thread, Member otherParticipant, List<Message> messages) {
             List<MessageDTO> messageDTOs = messages.stream()

--- a/src/main/java/com/example/template/domain/message/entity/Message.java
+++ b/src/main/java/com/example/template/domain/message/entity/Message.java
@@ -1,9 +1,13 @@
 package com.example.template.domain.message.entity;
 
 import com.example.template.domain.member.entity.Member;
+import com.example.template.domain.message.entity.enums.ReadStatus;
 import com.example.template.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Builder
 @Getter
@@ -18,9 +22,6 @@ public class Message extends BaseEntity {
     private Long id;
 
     private String content; // 내용
-
-    @Column(name = "img_url")
-    private String imgUrl;    // 사진 경로
 
     @Enumerated(EnumType.STRING)
     @Column(name = "read_status", nullable = false)
@@ -43,6 +44,9 @@ public class Message extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "message_thread_id")
     private MessageThread messageThread;
+
+    @OneToMany(mappedBy = "message", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<MessageImg> images = new ArrayList<>();
 
     public void updateDeletedBySender(boolean deleted) {
         this.deletedBySen = deleted;

--- a/src/main/java/com/example/template/domain/message/entity/Message.java
+++ b/src/main/java/com/example/template/domain/message/entity/Message.java
@@ -45,6 +45,7 @@ public class Message extends BaseEntity {
     @JoinColumn(name = "message_thread_id")
     private MessageThread messageThread;
 
+    @Builder.Default
     @OneToMany(mappedBy = "message", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<MessageImg> images = new ArrayList<>();
 

--- a/src/main/java/com/example/template/domain/message/entity/MessageImg.java
+++ b/src/main/java/com/example/template/domain/message/entity/MessageImg.java
@@ -1,0 +1,24 @@
+package com.example.template.domain.message.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Builder
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Entity
+public class MessageImg {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "message_img_id", nullable = false)
+    private Long id;
+
+    @Column(name = "img_url", nullable = false)
+    private String imgUrl; // 사진 경로
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "message_id")
+    private Message message;
+}

--- a/src/main/java/com/example/template/domain/message/entity/MessageParticipant.java
+++ b/src/main/java/com/example/template/domain/message/entity/MessageParticipant.java
@@ -42,4 +42,8 @@ public class MessageParticipant {
         this.leftAt = LocalDateTime.now();
         this.lastViewedMessage = lastViewedMessage;
     }
+
+    public void updateParticipationStatus(ParticipationStatus participationStatus) {
+        this.participationStatus = participationStatus;
+    }
 }

--- a/src/main/java/com/example/template/domain/message/entity/MessageParticipant.java
+++ b/src/main/java/com/example/template/domain/message/entity/MessageParticipant.java
@@ -1,6 +1,7 @@
 package com.example.template.domain.message.entity;
 
 import com.example.template.domain.member.entity.Member;
+import com.example.template.domain.message.entity.enums.ParticipationStatus;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/example/template/domain/message/entity/MessageParticipant.java
+++ b/src/main/java/com/example/template/domain/message/entity/MessageParticipant.java
@@ -26,8 +26,7 @@ public class MessageParticipant {
     @Column(name = "left_at")
     private LocalDateTime leftAt;   // 나간 시간
 
-    @Column(name = "last_viewed_message")
-    private Long lastViewedMessage; // 마지막으로 본 메시지 ID
+    // TODO 마지막으로 본 쪽지 id 필드 삭제 - leftAt으로 나간 시간 이후 받은 쪽지만 필터링 가능
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -37,10 +36,9 @@ public class MessageParticipant {
     @JoinColumn(name = "message_thread_id")
     private MessageThread messageThread;
 
-    public void leaveThread(Long lastViewedMessage) {
+    public void leaveThread() {
         this.participationStatus = ParticipationStatus.LEFT;
         this.leftAt = LocalDateTime.now();
-        this.lastViewedMessage = lastViewedMessage;
     }
 
     public void updateParticipationStatus(ParticipationStatus participationStatus) {

--- a/src/main/java/com/example/template/domain/message/entity/ReadStatus.java
+++ b/src/main/java/com/example/template/domain/message/entity/ReadStatus.java
@@ -1,6 +1,0 @@
-package com.example.template.domain.message.entity;
-
-public enum ReadStatus {
-    READ,
-    NOT_READ
-}

--- a/src/main/java/com/example/template/domain/message/entity/enums/ParticipationStatus.java
+++ b/src/main/java/com/example/template/domain/message/entity/enums/ParticipationStatus.java
@@ -1,4 +1,4 @@
-package com.example.template.domain.message.entity;
+package com.example.template.domain.message.entity.enums;
 
 public enum ParticipationStatus {
     ACTIVE,

--- a/src/main/java/com/example/template/domain/message/entity/enums/ReadStatus.java
+++ b/src/main/java/com/example/template/domain/message/entity/enums/ReadStatus.java
@@ -1,0 +1,6 @@
+package com.example.template.domain.message.entity.enums;
+
+public enum ReadStatus {
+    READ,
+    NOT_READ
+}

--- a/src/main/java/com/example/template/domain/message/exception/MessageErrorCode.java
+++ b/src/main/java/com/example/template/domain/message/exception/MessageErrorCode.java
@@ -11,20 +11,16 @@ import org.springframework.http.HttpStatus;
 public enum MessageErrorCode implements BaseErrorCode {
 
     // MessageThread ERROR 응답
-    THREAD_NOT_FOUND(HttpStatus.NOT_FOUND,
-            "THREAD401", "채팅방을 찾을 수 없습니다."),
+    THREAD_NOT_FOUND(HttpStatus.NOT_FOUND, "THREAD404", "채팅방을 찾을 수 없습니다."),
 
     // Message ERROR 응답
-    MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND,
-                      "MESSAGE401", "쪽지를 찾을 수 없습니다."),
-    PERMISSION_DENIED(HttpStatus.FORBIDDEN,
-            "MESSAGE402", "보낸 사람 또는 받는 사람이 아닙니다. 권한이 없습니다."),
+    MESSAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "MESSAGE404", "쪽지를 찾을 수 없습니다."),
+    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "MESSAGE403_1", "보낸 사람 또는 받는 사람이 아닙니다. 권한이 없습니다."),
+    SELF_MESSAGE_NOT_ALLOWED(HttpStatus.FORBIDDEN, "MESSAGE403_2", "자기 자신과의 쪽지는 허용되지 않습니다."),
 
     // MessageParticipant ERROR 응답
-    PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND,
-            "PARTICIPANT401", "채팅방에서 해당 참여자를 찾을 수 없습니다."),
-    OTHER_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND,
-            "PARTICIPANT402", "쪽지 상대를 찾을 수 없습니다.");
+    PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTICIPANT404_1", "채팅방에서 해당 참여자를 찾을 수 없습니다."),
+    OTHER_PARTICIPANT_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTICIPANT404_2", "쪽지 상대를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/template/domain/message/exception/MessageException.java
+++ b/src/main/java/com/example/template/domain/message/exception/MessageException.java
@@ -6,7 +6,7 @@ import lombok.Getter;
 
 @Getter
 public class MessageException extends GeneralException {
-    public MessageException(BaseErrorCode errorCode) {
+    public MessageException(MessageErrorCode errorCode) {
         super(errorCode);
     }
 }

--- a/src/main/java/com/example/template/domain/message/repository/MessageImgRepository.java
+++ b/src/main/java/com/example/template/domain/message/repository/MessageImgRepository.java
@@ -1,0 +1,7 @@
+package com.example.template.domain.message.repository;
+
+import com.example.template.domain.message.entity.MessageImg;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MessageImgRepository extends JpaRepository<MessageImg, Long> {
+}

--- a/src/main/java/com/example/template/domain/message/repository/MessageParticipantRepository.java
+++ b/src/main/java/com/example/template/domain/message/repository/MessageParticipantRepository.java
@@ -3,7 +3,7 @@ package com.example.template.domain.message.repository;
 import com.example.template.domain.member.entity.Member;
 import com.example.template.domain.message.entity.MessageParticipant;
 import com.example.template.domain.message.entity.MessageThread;
-import com.example.template.domain.message.entity.ParticipationStatus;
+import com.example.template.domain.message.entity.enums.ParticipationStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;

--- a/src/main/java/com/example/template/domain/message/repository/MessageRepository.java
+++ b/src/main/java/com/example/template/domain/message/repository/MessageRepository.java
@@ -11,11 +11,8 @@ import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 
 public interface MessageRepository extends JpaRepository<Message, Long> {
-    Optional<Message> findTopByReceiverAndReadStatusAndDeletedByRecFalseOrderByCreatedAtDesc(Member member, ReadStatus readStatus);
-
     long countByMessageThreadAndReceiverAndReadStatusAndDeletedByRecFalse(MessageThread messageThread, Member member, ReadStatus readStatus);
 
     @Query("SELECT m FROM Message m WHERE m.messageThread = :messageThread AND " +
@@ -39,4 +36,6 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
             "ORDER BY m.createdAt DESC")
     List<Message> findMessagesByMessageThreadAndMemberAndLeftAtAfter( @Param("messageThread") MessageThread messageThread,
                                                                       @Param("member") Member member, @Param("leftAt") LocalDateTime leftAt);
+
+    List<Message> findMessagesByMessageThreadAndReceiverAndReadStatus(MessageThread messageThread, Member member, ReadStatus readStatus);
 }

--- a/src/main/java/com/example/template/domain/message/repository/MessageRepository.java
+++ b/src/main/java/com/example/template/domain/message/repository/MessageRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -30,4 +31,12 @@ public interface MessageRepository extends JpaRepository<Message, Long> {
             "ORDER BY m.createdAt DESC")
     List<Message> findMessagesByMessageThreadAndMemberOrderByCreatedAtDesc(@Param("messageThread") MessageThread messageThread,
                                                                            @Param("member") Member member);
+
+    @Query("SELECT m FROM Message m WHERE m.messageThread = :messageThread AND " +
+            "((m.sender = :member AND m.deletedBySen = false) OR " +
+            "(m.receiver = :member AND m.deletedByRec = false)) " +
+            "AND (:leftAt IS NULL OR m.createdAt > :leftAt) " +
+            "ORDER BY m.createdAt DESC")
+    List<Message> findMessagesByMessageThreadAndMemberAndLeftAtAfter( @Param("messageThread") MessageThread messageThread,
+                                                                      @Param("member") Member member, @Param("leftAt") LocalDateTime leftAt);
 }

--- a/src/main/java/com/example/template/domain/message/repository/MessageRepository.java
+++ b/src/main/java/com/example/template/domain/message/repository/MessageRepository.java
@@ -3,7 +3,7 @@ package com.example.template.domain.message.repository;
 import com.example.template.domain.member.entity.Member;
 import com.example.template.domain.message.entity.Message;
 import com.example.template.domain.message.entity.MessageThread;
-import com.example.template.domain.message.entity.ReadStatus;
+import com.example.template.domain.message.entity.enums.ReadStatus;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;

--- a/src/main/java/com/example/template/domain/message/repository/MessageThreadRepository.java
+++ b/src/main/java/com/example/template/domain/message/repository/MessageThreadRepository.java
@@ -1,7 +1,17 @@
 package com.example.template.domain.message.repository;
 
+import com.example.template.domain.member.entity.Member;
 import com.example.template.domain.message.entity.MessageThread;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
 
 public interface MessageThreadRepository extends JpaRepository<MessageThread, Long> {
+    @Query("SELECT t FROM MessageThread t " +
+            "JOIN t.participants p1 " +
+            "JOIN t.participants p2 " +
+            "WHERE p1.member = :member1 AND p2.member = :member2")
+    Optional<MessageThread> findByParticipantsMember(@Param("member1") Member member1, @Param("member2") Member member2);
 }

--- a/src/main/java/com/example/template/domain/message/service/MessageCommandService.java
+++ b/src/main/java/com/example/template/domain/message/service/MessageCommandService.java
@@ -2,9 +2,12 @@ package com.example.template.domain.message.service;
 
 import com.example.template.domain.message.dto.request.MessageRequestDTO;
 import com.example.template.domain.message.dto.response.MessageResponseDTO;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 public interface MessageCommandService {
-    MessageResponseDTO.MessageDTO createMessage(MessageRequestDTO.CreateMessageDTO requestDTO);
+    MessageResponseDTO.MessageDTO createMessage(List<MultipartFile> files, MessageRequestDTO.CreateMessageDTO requestDTO);
 
     MessageResponseDTO.MessageDeleteDTO softDeleteMessage(Long messageId);
 

--- a/src/main/java/com/example/template/domain/message/service/MessageQueryService.java
+++ b/src/main/java/com/example/template/domain/message/service/MessageQueryService.java
@@ -9,5 +9,7 @@ public interface MessageQueryService {
 
     List<MessageResponseDTO.ThreadListDTO> getThreadList();
 
+    MessageResponseDTO.ThreadDTO getThread(Long writerId);
+
     MessageResponseDTO.MessageListDTO getMessageList(Long threadId);
 }

--- a/src/main/java/com/example/template/domain/message/service/MessageQueryServiceImpl.java
+++ b/src/main/java/com/example/template/domain/message/service/MessageQueryServiceImpl.java
@@ -4,6 +4,8 @@ import com.example.template.domain.member.entity.Member;
 import com.example.template.domain.member.repository.MemberRepository;
 import com.example.template.domain.message.dto.response.MessageResponseDTO;
 import com.example.template.domain.message.entity.*;
+import com.example.template.domain.message.entity.enums.ParticipationStatus;
+import com.example.template.domain.message.entity.enums.ReadStatus;
 import com.example.template.domain.message.exception.MessageErrorCode;
 import com.example.template.domain.message.exception.MessageException;
 import com.example.template.domain.message.repository.MessageParticipantRepository;

--- a/src/main/java/com/example/template/domain/message/service/MessageQueryServiceImpl.java
+++ b/src/main/java/com/example/template/domain/message/service/MessageQueryServiceImpl.java
@@ -108,8 +108,13 @@ public class MessageQueryServiceImpl implements MessageQueryService {
         // 쪽지 상대 찾기
         Member otherParticipant = getOtherParticipant(messageThread, member);
 
-        // 쪽지 목록 조회
-        List<Message> messages = messageRepository.findMessagesByMessageThreadAndMemberOrderByCreatedAtDesc(messageThread, member);
+        // 채팅방 참여 상태 조회
+        MessageParticipant messageParticipant = messageParticipantRepository.findByMemberAndMessageThread(member, messageThread)
+                .orElseThrow(() -> new MessageException(MessageErrorCode.PARTICIPANT_NOT_FOUND));
+
+        // leftAt 이후의 쪽지만 조회
+        List<Message> messages = messageRepository.findMessagesByMessageThreadAndMemberAndLeftAtAfter(
+                messageThread, member, messageParticipant.getLeftAt());
 
         return MessageResponseDTO.MessageListDTO.from(messageThread, otherParticipant, messages);
     }

--- a/src/main/java/com/example/template/domain/report/entity/Report.java
+++ b/src/main/java/com/example/template/domain/report/entity/Report.java
@@ -1,7 +1,6 @@
 package com.example.template.domain.report.entity;
 
 import com.example.template.domain.member.entity.Member;
-import com.example.template.domain.message.entity.ReadStatus;
 import com.example.template.global.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;

--- a/src/main/java/com/example/template/global/config/SwaggerConfig.java
+++ b/src/main/java/com/example/template/global/config/SwaggerConfig.java
@@ -8,6 +8,10 @@ import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
+
+import java.util.ArrayList;
 
 @Configuration
 public class SwaggerConfig {
@@ -31,5 +35,11 @@ public class SwaggerConfig {
                 .info(info)
                 .addSecurityItem(securityRequirement)
                 .components(components);
+    }
+
+    public SwaggerConfig(MappingJackson2HttpMessageConverter converter) {
+        var supportedMediaTypes = new ArrayList<>(converter.getSupportedMediaTypes());
+        supportedMediaTypes.add(new MediaType("application", "octet-stream"));
+        converter.setSupportedMediaTypes(supportedMediaTypes);
     }
 }


### PR DESCRIPTION
## ☝️Issue Number
- resolve #32

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 📌 개요
- 쪽지 생성, 조회, 삭제(soft delete) 로직 변경

## 🔎 Key Changes
- [♻️ refactor: Message 엔티티 구조 변경](https://github.com/Fill-ENERGY/BackEnd_Server/commit/907b628bb956c69cf5ad6ebc09f64aa8e4fc5a00) -> 한번에 이미지 여러 장 전송 가능. img 필드 대신 테이블 추가
- [♻️ refactor: 쪽지 생성 로직 별도 메서드로 분리](https://github.com/Fill-ENERGY/BackEnd_Server/commit/11b2be9b5a58120a3b4d49db7bd5b4acfa73d613)   
- [✨ feat: 쪽지 s3 이미지 업로드 구현](https://github.com/Fill-ENERGY/BackEnd_Server/commit/f8b59e74edaa4613faab535e1d87c9a1d7c02d42) -> 내용, 이미지 api 분리해서 리팩토링 예정. 리팩토링 후 자세히 봐주시면 될 것 같습니다.   
- [✨ feat: Swagger 설정에 application/octet-stream 미디어 타입 추가](https://github.com/Fill-ENERGY/BackEnd_Server/commit/1c18d7c334c27cc8e080e9b2d64e17f8d0a3ed88)  
- [✨ feat: 채팅방을 나간 상태에서 쪽지를 전송/수신한 경우, 참여 상태 ACTIVE로 업데이트](https://github.com/Fill-ENERGY/BackEnd_Server/commit/70cda3fc2ecc949ce9be5fd66440da7ae7bf9186)   
- [♻️ refactor: 최근 쪽지가 사진인 경우, 채팅방 목록에서 텍스트로 표시](https://github.com/Fill-ENERGY/BackEnd_Server/commit/6ad098c83fdb77680f145e466be1477346b6ebe0)  
- [✨ feat: 채팅방 조회 API 구현](https://github.com/Fill-ENERGY/BackEnd_Server/commit/6d77b9c1394c9019670c2b64cfd9cf4de2703bd9) -> 커뮤니티에서 채팅하기 할 때 채팅방 존재 여부 확인
- [♻️ refactor: lastViewedMessage 필드 삭제, 채팅방을 나간 이후 받은 쪽지만 조회하도록 변경](https://github.com/Fill-ENERGY/BackEnd_Server/commit/1dee0e282f47104794c444faa2772bb2945c66f6)  
- [♻️ refactor: 채팅방 나가기 전 안 읽은 쪽지를 읽음 상태로 업데이트 후 나감 처리](https://github.com/Fill-ENERGY/BackEnd_Server/commit/77d041c30d6849954ba5f12adcf219f72713bbfb) -> 밀어서 나가기 하는 경우

## 💌 To Reviewers
- 변경 내용이 많아서 이슈에 작성했던 삭제(hard delete)는 별도의 pr로 올리겠습니다.
- 이후 작업 예정
  - hard delete
  - 로그인한 멤버 정보는 하드코딩 되어있음. 실제 로그인한 멤버 정보로 수정 필요
  - 커서 페이지네이션 적용
  - 차단한 사용자 관련 처리
  - 내용, 이미지 api 분리

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
