### PR TITLE
✨ [FEAT] 카카오 OAuth 구현 (#17)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,15 @@ dependencies {
 
 	// WebFlux
 	implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+	// OAuth 2.0
+	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
+
+	// Json을 결과로 매핑하기 위한 의존성
+	implementation 'com.google.code.gson:gson'
+
+	//
+	implementation 'org.springframework.boot:spring-boot-starter-freemarker:2.5.4'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/template/FillEnergyApplication.java
+++ b/src/main/java/com/example/template/FillEnergyApplication.java
@@ -16,9 +16,4 @@ public class FillEnergyApplication {
 		SpringApplication.run(FillEnergyApplication.class, args);
 	}
 
-	@Bean
-	public RestTemplate getRestTemplate() {
-		return new RestTemplate();
-	}
-
 }

--- a/src/main/java/com/example/template/FillEnergyApplication.java
+++ b/src/main/java/com/example/template/FillEnergyApplication.java
@@ -2,8 +2,10 @@ package com.example.template;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.web.client.RestTemplate;
 
 @SpringBootApplication
 @EnableJpaAuditing
@@ -12,6 +14,11 @@ public class FillEnergyApplication {
 
 	public static void main(String[] args) {
 		SpringApplication.run(FillEnergyApplication.class, args);
+	}
+
+	@Bean
+	public RestTemplate getRestTemplate() {
+		return new RestTemplate();
 	}
 
 }

--- a/src/main/java/com/example/template/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/template/domain/member/controller/MemberController.java
@@ -33,25 +33,13 @@ public class MemberController {
         return ApiResponse.onSuccess(memberService.signup(requestDTO));
     }
 
-    @Operation(summary = "일반 로그인", description = "이메일, 비밀번호를 입력받아 로그인을 진행합니다." +
-            "반환 값으로 JWT accessToken과 refreshToken이 발급됨. accessToken 값을 Authorize에 인증")
-    @PostMapping("/login")
-    public ApiResponse<MemberResponseDTO.LoginResultDTO> login(@Valid @RequestBody MemberRequestDTO.LoginDTO requestDTO) {
-        return ApiResponse.onSuccess(memberService.login(requestDTO));
+    @Operation(summary = "카카오 로그인 및 회원가입", description = "카카오 accessToken을 입력받아 로그인 또는 회원가입을 처리합니다. " +
+            "반환 값으로 JWT accessToken과 refreshToken이 발급되며, accessToken 값을 Authorize에 인증")
+    @PostMapping("/social/loginorsignup/kakao")
+    public ApiResponse<MemberResponseDTO.LoginResultDTO> loginOrSignupByKakao(@Valid @RequestBody SocialRequestDTO.LoginDTO requestDTO) {
+        return ApiResponse.onSuccess(kakaoService.loginOrSignupByKakao(requestDTO));
     }
 
-    @Operation(summary = "카카오 회원가입", description = "카카오 accessToken, 이메일을 입력받아 회원가입을 진행합니다. 이메일은 중복 불가.")
-    @PostMapping("/social/signup/kakao")
-    public ApiResponse<MemberResponseDTO.SignupResultDTO> signupByKakao(@Valid @RequestBody SocialRequestDTO.SignupDTO requestDTO) {
-        return ApiResponse.onSuccess(kakaoService.signupByKakao(requestDTO));
-    }
-
-    @Operation(summary = "카카오 로그인", description = "카카오 accessToken, 이메일을 입력받아 로그인." +
-            "반환 값으로 JWT accessToken과 refreshToken이 발급됨. accessToken 값을 Authorize에 인증")
-    @PostMapping("/social/login/kakao")
-    public ApiResponse<MemberResponseDTO.LoginResultDTO> loginByKakao(@Valid @RequestBody SocialRequestDTO.LoginDTO requestDTO) {
-        return ApiResponse.onSuccess(kakaoService.loginByKakao(requestDTO));
-    }
 
     @Operation(summary = "로그아웃")
     @PostMapping("/logout")

--- a/src/main/java/com/example/template/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/template/domain/member/controller/MemberController.java
@@ -2,9 +2,10 @@ package com.example.template.domain.member.controller;
 
 import com.example.template.domain.member.dto.MemberRequestDTO;
 import com.example.template.domain.member.dto.MemberResponseDTO;
+import com.example.template.domain.member.dto.SocialRequestDTO;
 import com.example.template.domain.member.entity.Member;
 import com.example.template.domain.member.jwt.dto.JwtDTO;
-import com.example.template.domain.member.jwt.util.JwtProvider;
+import com.example.template.domain.member.service.KakaoService;
 import com.example.template.domain.member.service.MemberService;
 import com.example.template.global.annotation.AuthenticatedMember;
 import com.example.template.global.apiPayload.ApiResponse;
@@ -24,6 +25,7 @@ import org.springframework.web.bind.annotation.*;
 public class MemberController {
 
     private final MemberService memberService;
+    private final KakaoService kakaoService;
 
     @Operation(summary = "일반 회원가입", description = "이름, 이메일, 비밀번호를 입력받아 회원가입을 진행합니다. 이메일은 중복 불가, 비밀먼호는 인코딩 되어 저장됨. 참고)")
     @PostMapping("/signup")
@@ -36,6 +38,19 @@ public class MemberController {
     @PostMapping("/login")
     public ApiResponse<MemberResponseDTO.LoginResultDTO> login(@Valid @RequestBody MemberRequestDTO.LoginDTO requestDTO) {
         return ApiResponse.onSuccess(memberService.login(requestDTO));
+    }
+
+    @Operation(summary = "카카오 회원가입", description = "카카오 accessToken, 이메일을 입력받아 회원가입을 진행합니다. 이메일은 중복 불가.")
+    @PostMapping("/social/signup/kakao")
+    public ApiResponse<MemberResponseDTO.SignupResultDTO> signupByKakao(@Valid @RequestBody SocialRequestDTO.SignupDTO requestDTO) {
+        return ApiResponse.onSuccess(kakaoService.signupByKakao(requestDTO));
+    }
+
+    @Operation(summary = "카카오 로그인", description = "카카오 accessToken, 이메일을 입력받아 로그인." +
+            "반환 값으로 JWT accessToken과 refreshToken이 발급됨. accessToken 값을 Authorize에 인증")
+    @PostMapping("/social/login/kakao")
+    public ApiResponse<MemberResponseDTO.LoginResultDTO> loginByKakao(@Valid @RequestBody SocialRequestDTO.LoginDTO requestDTO) {
+        return ApiResponse.onSuccess(kakaoService.loginByKakao(requestDTO));
     }
 
     @Operation(summary = "로그아웃")
@@ -58,6 +73,7 @@ public class MemberController {
                 member.getEmail(),
                 member.getName()
         );
-        return ApiResponse.onSuccess(memberDTO);}
+        return ApiResponse.onSuccess(memberDTO);
+    }
 
 }

--- a/src/main/java/com/example/template/domain/member/controller/OAuthController.java
+++ b/src/main/java/com/example/template/domain/member/controller/OAuthController.java
@@ -5,11 +5,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.ModelAndView;
 
 @Slf4j
-@RestController
+@Controller
 @RequiredArgsConstructor
 @RequestMapping("/oauth/kakao")
 public class OAuthController {

--- a/src/main/java/com/example/template/domain/member/controller/OAuthController.java
+++ b/src/main/java/com/example/template/domain/member/controller/OAuthController.java
@@ -1,0 +1,51 @@
+package com.example.template.domain.member.controller;
+
+import com.example.template.domain.member.service.KakaoService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.ModelAndView;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/oauth/kakao")
+public class OAuthController {
+    private final Environment env;
+    private final KakaoService kakaoService;
+
+    @Value("${spring.url.base}")
+    private String baseUrl;
+
+    @Value("${social.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${social.kakao.redirect}")
+    private String kakaoRedirectUri;
+
+    @GetMapping("/login")
+    public ModelAndView socialLogin(ModelAndView mav) {
+
+        StringBuilder loginUri = new StringBuilder()
+                .append(env.getProperty("social.kakao.url.login"))
+                .append("?response_type=code")
+                .append("&client_id=").append(kakaoClientId)
+                .append("&redirect_uri=").append(baseUrl).append(kakaoRedirectUri);
+        mav.addObject("loginUrl", loginUri);
+        mav.setViewName("social/login");
+        return mav;
+    }
+
+    @GetMapping(value = "/redirect")
+    public ModelAndView redirectKakao(
+            ModelAndView mav,
+            @RequestHeader("Authorization Code")
+            @RequestParam String code) {
+
+        mav.addObject("authInfo", kakaoService.getKakaoTokenInfo(code));
+        mav.setViewName("social/redirect");
+        return mav;
+    }
+}

--- a/src/main/java/com/example/template/domain/member/dto/KakaoProfile.java
+++ b/src/main/java/com/example/template/domain/member/dto/KakaoProfile.java
@@ -1,0 +1,23 @@
+package com.example.template.domain.member.dto;
+
+import lombok.Getter;
+import lombok.ToString;
+
+@Getter
+public class KakaoProfile {
+    private Long id;
+    private Properties properties;
+    private KakaoAccount kakao_account;
+
+    @Getter
+    @ToString
+    public static class KakaoAccount {
+        private String email;
+    }
+
+    @Getter
+    @ToString
+    public static class Properties {
+        private String nickname;
+    }
+}

--- a/src/main/java/com/example/template/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/example/template/domain/member/dto/MemberRequestDTO.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
+import lombok.Builder;
 import lombok.Getter;
 
 public class MemberRequestDTO {
@@ -23,6 +24,7 @@ public class MemberRequestDTO {
     }
 
     @Getter
+    @Builder
     public static class SignupDTO {
         @Size(max = 10, message = "이름은 최대 10자까지 입력 가능합니다.")
         @Schema(description = "name", example = "힘전소")
@@ -44,11 +46,21 @@ public class MemberRequestDTO {
         @Schema(description = "passwordCheck", example = "test1234!!")
         private String passwordCheck;
 
+        private String provider;
+
         public Member toEntity(String encodedPw){
             return Member.builder()
                     .email(email)
                     .password(encodedPw)
                     .name(name)
+                    .build();
+        }
+
+        public Member toEntity() {
+            return Member.builder()
+                    .email(email)
+                    .name(name)
+                    .provider(provider)
                     .build();
         }
     }

--- a/src/main/java/com/example/template/domain/member/dto/MemberRequestDTO.java
+++ b/src/main/java/com/example/template/domain/member/dto/MemberRequestDTO.java
@@ -1,6 +1,7 @@
 package com.example.template.domain.member.dto;
 
 import com.example.template.domain.member.entity.Member;
+import com.example.template.domain.member.entity.ProviderType;
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Pattern;
@@ -46,7 +47,7 @@ public class MemberRequestDTO {
         @Schema(description = "passwordCheck", example = "test1234!!")
         private String passwordCheck;
 
-        private String provider;
+        private ProviderType provider;
 
         public Member toEntity(String encodedPw){
             return Member.builder()

--- a/src/main/java/com/example/template/domain/member/dto/RetKakaoOAuth.java
+++ b/src/main/java/com/example/template/domain/member/dto/RetKakaoOAuth.java
@@ -1,0 +1,14 @@
+package com.example.template.domain.member.dto;
+
+import lombok.Getter;
+
+@Getter
+public class RetKakaoOAuth {
+    private String token_type;
+    private String access_token;
+    private Integer expires_in;
+    private String refresh_token;
+    private String refresh_token_expires_in;
+    private String scope;
+}
+

--- a/src/main/java/com/example/template/domain/member/dto/SocialRequestDTO.java
+++ b/src/main/java/com/example/template/domain/member/dto/SocialRequestDTO.java
@@ -1,0 +1,18 @@
+package com.example.template.domain.member.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+
+public class SocialRequestDTO {
+    @Getter
+    public static class LoginDTO{
+        @NotBlank(message = "[ERROR] 토큰 입력은 필수 입니다.")
+        String accessToken;
+    }
+
+    @Getter
+    public static class SignupDTO{
+        @NotBlank(message = "[ERROR] 토큰 입력은 필수 입니다.")
+        String accessToken;
+    }
+}

--- a/src/main/java/com/example/template/domain/member/entity/Member.java
+++ b/src/main/java/com/example/template/domain/member/entity/Member.java
@@ -24,12 +24,15 @@ public class Member extends BaseEntity {
     @Column(name = "member_name", nullable = false)
     private String name;    // 이름
 
-    @Column(name = "member_nickname", nullable = false)
+    @Column(name = "member_nickname")
     private String nickname;    // 닉네임
 
     @JsonProperty(access = JsonProperty.Access.WRITE_ONLY)
     @Column(name = "member_password")
     private String password;    // 비밀번호
+
+    @Column(length = 100) // provider 추가 (kakao)
+    private String provider;
 
     @Column(name = "member_role")
     private String role;    // 역할
@@ -43,5 +46,11 @@ public class Member extends BaseEntity {
     public void updateProfile(ProfileRequestDTO.UpdateProfileDTO updateProfileDTO, String imageUrl) {
         this.nickname = updateProfileDTO.getNickname();
         this.profileImg = imageUrl;
+    }
+
+    public void setMemberNickname(String memberNickname) {
+        this.nickname = (memberNickname != null && !memberNickname.isEmpty())
+                ? memberNickname
+                : this.email.split("@")[0];
     }
 }

--- a/src/main/java/com/example/template/domain/member/entity/Member.java
+++ b/src/main/java/com/example/template/domain/member/entity/Member.java
@@ -31,8 +31,9 @@ public class Member extends BaseEntity {
     @Column(name = "member_password")
     private String password;    // 비밀번호
 
-    @Column(length = 100) // provider 추가 (kakao)
-    private String provider;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "member_provider", length = 100) // provider 추가 (kakao)
+    private ProviderType provider;
 
     @Column(name = "member_role")
     private String role;    // 역할

--- a/src/main/java/com/example/template/domain/member/entity/ProviderType.java
+++ b/src/main/java/com/example/template/domain/member/entity/ProviderType.java
@@ -1,0 +1,10 @@
+package com.example.template.domain.member.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum ProviderType {
+    KAKAO
+}

--- a/src/main/java/com/example/template/domain/member/exception/MemberErrorCode.java
+++ b/src/main/java/com/example/template/domain/member/exception/MemberErrorCode.java
@@ -10,10 +10,15 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor
 public enum MemberErrorCode implements BaseErrorCode {
 
+    // 가장 일반적인 응답
+    _INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON500", "서버 에러, 관리자에게 문의 바랍니다."),
+
     //해당 멤버가 없을 때
     MEMBER_NOT_FOUND(HttpStatus.NOT_FOUND, "MEMBER401", "해당 멤버를 찾을 수 없습니다"),
     //비밀번호 재확인이 올바르지 않을 때
     PASSWORD_NOT_EQUAL(HttpStatus.NOT_FOUND, "MEMBER402", "비밀번호가 일치하지 않습니다."),
+    // 이메일 없을 때
+    EMAIL_NOT_EXIST(HttpStatus.BAD_REQUEST, "USER405", "사용자 이메일이 존재하지 않습니다."),
     //이메일이 중복될 때
     USER_ALREADY_EXIST(HttpStatus.NOT_FOUND, "MEMBER403", "사용자가 이미 존재합니다."),
     //비밀번호를 잘 못 입력했을 때

--- a/src/main/java/com/example/template/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/template/domain/member/repository/MemberRepository.java
@@ -1,6 +1,7 @@
 package com.example.template.domain.member.repository;
 
 import com.example.template.domain.member.entity.Member;
+import com.example.template.domain.member.entity.ProviderType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
@@ -9,5 +10,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
     boolean existsByEmail(String email);
-    Optional<Member> findByEmailAndProvider(String email, String provider);
+    Optional<Member> findByEmailAndProvider(String email, ProviderType provider);
 }

--- a/src/main/java/com/example/template/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/example/template/domain/member/repository/MemberRepository.java
@@ -9,4 +9,5 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
     boolean existsByEmail(String email);
+    Optional<Member> findByEmailAndProvider(String email, String provider);
 }

--- a/src/main/java/com/example/template/domain/member/service/KakaoService.java
+++ b/src/main/java/com/example/template/domain/member/service/KakaoService.java
@@ -12,7 +12,5 @@ public interface KakaoService {
 
     void kakaoUnlink(String accessToken);
 
-    MemberResponseDTO.SignupResultDTO signupByKakao(SocialRequestDTO.SignupDTO requestDto);
-
-    MemberResponseDTO.LoginResultDTO loginByKakao(SocialRequestDTO.LoginDTO requestDto);
+    MemberResponseDTO.LoginResultDTO loginOrSignupByKakao(SocialRequestDTO.LoginDTO requestDTO);
 }

--- a/src/main/java/com/example/template/domain/member/service/KakaoService.java
+++ b/src/main/java/com/example/template/domain/member/service/KakaoService.java
@@ -8,8 +8,6 @@ import com.example.template.domain.member.dto.SocialRequestDTO;
 public interface KakaoService {
     RetKakaoOAuth getKakaoTokenInfo(String code);
 
-    KakaoProfile getKakaoProfile(String kakaoAccessToken);
-
     void kakaoUnlink(String accessToken);
 
     MemberResponseDTO.LoginResultDTO loginOrSignupByKakao(SocialRequestDTO.LoginDTO requestDTO);

--- a/src/main/java/com/example/template/domain/member/service/KakaoService.java
+++ b/src/main/java/com/example/template/domain/member/service/KakaoService.java
@@ -1,0 +1,18 @@
+package com.example.template.domain.member.service;
+
+import com.example.template.domain.member.dto.KakaoProfile;
+import com.example.template.domain.member.dto.MemberResponseDTO;
+import com.example.template.domain.member.dto.RetKakaoOAuth;
+import com.example.template.domain.member.dto.SocialRequestDTO;
+
+public interface KakaoService {
+    RetKakaoOAuth getKakaoTokenInfo(String code);
+
+    KakaoProfile getKakaoProfile(String kakaoAccessToken);
+
+    void kakaoUnlink(String accessToken);
+
+    MemberResponseDTO.SignupResultDTO signupByKakao(SocialRequestDTO.SignupDTO requestDto);
+
+    MemberResponseDTO.LoginResultDTO loginByKakao(SocialRequestDTO.LoginDTO requestDto);
+}

--- a/src/main/java/com/example/template/domain/member/service/KakaoServiceImpl.java
+++ b/src/main/java/com/example/template/domain/member/service/KakaoServiceImpl.java
@@ -1,0 +1,145 @@
+package com.example.template.domain.member.service;
+
+import com.example.template.domain.member.dto.*;
+import com.example.template.domain.member.entity.Member;
+import com.example.template.domain.member.exception.MemberErrorCode;
+import com.example.template.domain.member.exception.MemberException;
+import com.example.template.domain.member.jwt.userdetails.PrincipalDetails;
+import com.example.template.domain.member.jwt.util.JwtProvider;
+import com.example.template.domain.member.repository.MemberRepository;
+import com.example.template.global.util.RedisUtil;
+import com.google.gson.Gson;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.env.Environment;
+import org.springframework.http.*;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class KakaoServiceImpl implements KakaoService{
+    private final Environment env;
+    private final RestTemplate restTemplate;
+    private final Gson gson;
+    private final MemberService memberService;
+    private final JwtProvider jwtProvider;
+    private final MemberRepository memberRepository;
+
+    @Value("${spring.url.base}")
+    private String baseUrl;
+
+    @Value("${social.kakao.client-id}")
+    private String kakaoClientId;
+
+    @Value("${social.kakao.redirect}")
+    private String kakaoRedirectUri;
+
+    // 토큰 정보 가져오기
+    @Override
+    public RetKakaoOAuth getKakaoTokenInfo(String code) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", kakaoClientId);
+        params.add("redirect_uri", baseUrl + kakaoRedirectUri);
+        params.add("code", code);
+
+        String requestUri = env.getProperty("social.kakao.url.token");
+        if (requestUri == null) throw new MemberException(MemberErrorCode._INTERNAL_SERVER_ERROR);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(params, headers);
+        ResponseEntity<String> response = restTemplate.postForEntity(requestUri, request, String.class);
+        if (response.getStatusCode() == HttpStatus.OK)
+            return gson.fromJson(response.getBody(), RetKakaoOAuth.class);
+        throw new MemberException(MemberErrorCode._INTERNAL_SERVER_ERROR);
+    }
+
+    //사용자 정보 조회 요청 보내기
+    @Override
+    public KakaoProfile getKakaoProfile(String kakaoAccessToken) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Authorization", "Bearer " + kakaoAccessToken);
+
+        String requestUrl = env.getProperty("social.kakao.url.profile");
+        if (requestUrl == null) throw new MemberException(MemberErrorCode._INTERNAL_SERVER_ERROR);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(null, headers);
+        try {
+            ResponseEntity<String> response = restTemplate.postForEntity(requestUrl, request, String.class);
+            if (response.getStatusCode() == HttpStatus.OK)
+                return gson.fromJson(response.getBody(), KakaoProfile.class);
+        } catch (Exception e) {
+            log.error(e.toString());
+            throw new MemberException(MemberErrorCode._INTERNAL_SERVER_ERROR);
+        }
+        throw new MemberException(MemberErrorCode._INTERNAL_SERVER_ERROR);
+    }
+
+    @Override
+    public void kakaoUnlink(String accessToken) {
+        String unlinkUrl = env.getProperty("social.kakao.url.unlink");
+        if (unlinkUrl == null) throw new MemberException(MemberErrorCode._INTERNAL_SERVER_ERROR);
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        headers.set("Authorization", "Bearer " + accessToken);
+
+        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<>(null, headers);
+        ResponseEntity<String> response = restTemplate.postForEntity(unlinkUrl, request, String.class);
+
+        if (response.getStatusCode() == HttpStatus.OK) return;
+        throw new MemberException(MemberErrorCode._INTERNAL_SERVER_ERROR);
+    }
+
+    @Override
+    public MemberResponseDTO.SignupResultDTO signupByKakao(SocialRequestDTO.SignupDTO requestDTO) {
+        KakaoProfile  kakaoProfile = getKakaoProfile(requestDTO.getAccessToken());
+        if (kakaoProfile == null) throw new MemberException(MemberErrorCode.MEMBER_NOT_FOUND);
+        if (kakaoProfile.getKakao_account().getEmail() == null) {
+            kakaoUnlink(requestDTO.getAccessToken());
+            throw new MemberException(MemberErrorCode.EMAIL_NOT_EXIST);
+        }
+
+        MemberRequestDTO.SignupDTO signupRequestDto = MemberRequestDTO.SignupDTO.builder()
+                .email(kakaoProfile.getKakao_account().getEmail())
+                .name(kakaoProfile.getProperties().getNickname())
+                .provider("kakao")
+                .build();
+
+        return memberService.socialSignup(signupRequestDto);
+    }
+
+    @Override
+    public MemberResponseDTO.LoginResultDTO loginByKakao(SocialRequestDTO.LoginDTO requestDTO) {
+        KakaoProfile kakaoProfile = getKakaoProfile(requestDTO.getAccessToken());
+        if (kakaoProfile == null) throw new MemberException(MemberErrorCode.MEMBER_NOT_FOUND);
+
+        String kakaoEmail = kakaoProfile.getKakao_account().getEmail();
+        if (kakaoEmail == null) throw new MemberException(MemberErrorCode.EMAIL_NOT_EXIST);
+
+        Member member = memberRepository.findByEmailAndProvider(kakaoEmail, "kakao")
+                .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
+
+        PrincipalDetails userDetails = new PrincipalDetails(member);
+
+        String accessToken = jwtProvider.createJwtAccessToken(userDetails);
+        String refreshToken = jwtProvider.createJwtRefreshToken(userDetails);
+
+        return MemberResponseDTO.LoginResultDTO.builder()
+                .userId(member.getId())
+                .createdAt(LocalDateTime.now())
+                .accessToken(accessToken)
+                .refreshToken(refreshToken)
+                .build();
+    }
+}

--- a/src/main/java/com/example/template/domain/member/service/KakaoServiceImpl.java
+++ b/src/main/java/com/example/template/domain/member/service/KakaoServiceImpl.java
@@ -64,8 +64,7 @@ public class KakaoServiceImpl implements KakaoService{
     }
 
     //사용자 정보 조회 요청 보내기
-    @Override
-    public KakaoProfile getKakaoProfile(String kakaoAccessToken) {
+    private KakaoProfile getKakaoProfile(String kakaoAccessToken) {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
         headers.set("Authorization", "Bearer " + kakaoAccessToken);

--- a/src/main/java/com/example/template/domain/member/service/KakaoServiceImpl.java
+++ b/src/main/java/com/example/template/domain/member/service/KakaoServiceImpl.java
@@ -2,6 +2,7 @@ package com.example.template.domain.member.service;
 
 import com.example.template.domain.member.dto.*;
 import com.example.template.domain.member.entity.Member;
+import com.example.template.domain.member.entity.ProviderType;
 import com.example.template.domain.member.exception.MemberErrorCode;
 import com.example.template.domain.member.exception.MemberException;
 import com.example.template.domain.member.jwt.userdetails.PrincipalDetails;
@@ -113,7 +114,7 @@ public class KakaoServiceImpl implements KakaoService{
             throw new MemberException(MemberErrorCode.EMAIL_NOT_EXIST);
         }
 
-        return memberRepository.findByEmailAndProvider(kakaoEmail, "kakao")
+        return memberRepository.findByEmailAndProvider(kakaoEmail, ProviderType.KAKAO)
                 .map(member -> {
                     // 로그인 로직
                     PrincipalDetails userDetails = new PrincipalDetails(member);
@@ -132,13 +133,13 @@ public class KakaoServiceImpl implements KakaoService{
                     MemberRequestDTO.SignupDTO signupRequestDto = MemberRequestDTO.SignupDTO.builder()
                             .email(kakaoEmail)
                             .name(kakaoProfile.getProperties().getNickname())
-                            .provider("kakao")
+                            .provider(ProviderType.KAKAO)
                             .build();
 
                     memberService.socialSignup(signupRequestDto);
 
                     // 로그인 로직 (회원가입 후 바로 로그인 처리)
-                    Member member = memberRepository.findByEmailAndProvider(kakaoEmail, "kakao")
+                    Member member = memberRepository.findByEmailAndProvider(kakaoEmail, ProviderType.KAKAO)
                             .orElseThrow(() -> new MemberException(MemberErrorCode.MEMBER_NOT_FOUND));
 
                     PrincipalDetails userDetails = new PrincipalDetails(member);

--- a/src/main/java/com/example/template/domain/member/service/MemberService.java
+++ b/src/main/java/com/example/template/domain/member/service/MemberService.java
@@ -9,6 +9,7 @@ import jakarta.servlet.http.HttpServletRequest;
 public interface MemberService {
     MemberResponseDTO.SignupResultDTO signup(MemberRequestDTO.SignupDTO signupDTO);
     MemberResponseDTO.LoginResultDTO login(MemberRequestDTO.LoginDTO loginDTO);
+    MemberResponseDTO.SignupResultDTO socialSignup(MemberRequestDTO.SignupDTO signupDTO);
     void logout(HttpServletRequest request);
     JwtDTO reissueToken(String refreshToken);
 }

--- a/src/main/java/com/example/template/domain/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/example/template/domain/member/service/MemberServiceImpl.java
@@ -69,6 +69,19 @@ public class MemberServiceImpl implements MemberService{
     }
 
     @Override
+    public MemberResponseDTO.SignupResultDTO socialSignup(MemberRequestDTO.SignupDTO signupDTO) {
+        if (memberRepository
+                .findByEmailAndProvider(signupDTO.getEmail(), signupDTO.getProvider())
+                .isPresent()
+        ) throw new MemberException(MemberErrorCode.USER_ALREADY_EXIST);
+        Member member = memberRepository.save(signupDTO.toEntity());
+
+        member.setMemberNickname(member.getNickname());
+
+        return MemberResponseDTO.SignupResultDTO.from(member);
+    }
+
+    @Override
     public void logout(HttpServletRequest request) {
         try {
             String accessToken = jwtProvider.resolveAccessToken(request);

--- a/src/main/java/com/example/template/global/config/SecurityConfig.java
+++ b/src/main/java/com/example/template/global/config/SecurityConfig.java
@@ -27,8 +27,8 @@ import java.util.stream.Stream;
 @RequiredArgsConstructor
 public class SecurityConfig {
     private final String[] swaggerUrls = {"/swagger-ui/**", "/v3/**"};
-    private final String[] authUrls = {"/", "/api/v1/members/signup/**", "/members/social/**", "/api/v1/members/login/**",
-            "/api/v1/members/reissue/**"}; // TODO 추후 API 개발
+    private final String[] authUrls = {"/", "/api/v1/members/signup/**", "/oauth/kakao/**", "/api/v1/members/login/**",
+            "/api/v1/members/reissue/**", "/api/v1/members/social/**"}; // TODO 추후 API 개발
     private final String[] allowedUrls = Stream.concat(Arrays.stream(swaggerUrls), Arrays.stream(authUrls))
             .toArray(String[]::new);
 

--- a/src/main/java/com/example/template/global/config/WebConfig.java
+++ b/src/main/java/com/example/template/global/config/WebConfig.java
@@ -2,7 +2,9 @@ package com.example.template.global.config;
 
 import com.example.template.global.annotation.AuthenticatedMemberArgumentResolver;
 import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.client.RestTemplate;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -17,5 +19,10 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(authenticatedMemberArgumentResolver);
+    }
+
+    @Bean
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
     }
 }

--- a/src/main/resources/templates/social/login.ftl
+++ b/src/main/resources/templates/social/login.ftl
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>카카오 OAuth 테스트 페이지</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f7f7f7;
+            text-align: center;
+            padding-top: 50px;
+        }
+        #container {
+            background-color: white;
+            border-radius: 8px;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+            display: inline-block;
+            padding: 30px;
+            width: 300px;
+        }
+        h1 {
+            color: #ffeb00;
+            font-size: 24px;
+            margin-bottom: 20px;
+        }
+        p {
+            font-size: 16px;
+            margin-bottom: 30px;
+            color: #333;
+        }
+        button {
+            background-color: #ffeb00;
+            border: none;
+            border-radius: 4px;
+            color: black;
+            font-size: 16px;
+            padding: 10px 20px;
+            cursor: pointer;
+        }
+        button:hover {
+            background-color: #ffcc00;
+        }
+    </style>
+</head>
+<body>
+<div id="container">
+    <h1>카카오 OAuth<br>테스트 페이지</h1>
+    <p>이 페이지는 카카오 OAuth 테스트 페이지입니다.</p>
+    <button onclick="popupKakaoLogin()">KakaoLogin</button>
+</div>
+<script>
+    function popupKakaoLogin() {
+        window.open('${loginUrl}', 'popupKakaoLogin', 'width=730,height=400,scrollbars=0,toolbar=0,menubar=no')
+    }
+</script>
+</body>
+</html>

--- a/src/main/resources/templates/social/redirect.ftl
+++ b/src/main/resources/templates/social/redirect.ftl
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8">
+    <title>카카오 OAuth 정보</title>
+    <style>
+        body {
+            font-family: Arial, sans-serif;
+            background-color: #f7f7f7;
+            color: #333;
+            text-align: center;
+            padding-top: 50px;
+        }
+        #container {
+            background-color: white;
+            border-radius: 8px;
+            box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1);
+            display: inline-block;
+            padding: 30px;
+            width: 350px;
+        }
+        h1 {
+            color: #ffeb00;
+            font-size: 24px;
+            margin-bottom: 20px;
+        }
+        ol {
+            text-align: left;
+            padding: 0;
+            margin: 20px 0;
+        }
+        li {
+            background-color: #fafafa;
+            border-radius: 4px;
+            margin-bottom: 10px;
+            padding: 10px;
+            border: 1px solid #ddd;
+        }
+        li span {
+            font-weight: bold;
+            color: #555;
+        }
+    </style>
+</head>
+<body>
+<div id="container">
+    <h1>카카오 OAuth 정보</h1>
+    <ol>
+        <li><span>token_type:</span> ${authInfo.token_type}</li>
+        <li><span>access_token:</span> ${authInfo.access_token}</li>
+        <li><span>expires_in:</span> ${authInfo.expires_in}</li>
+        <li><span>refresh_token:</span> ${authInfo.refresh_token}</li>
+        <li><span>refresh_token_expires_in:</span> ${authInfo.refresh_token_expires_in}</li>
+        <li><span>scope:</span> ${authInfo.scope}</li>
+    </ol>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## ☝️Issue Number
- resolve #17 

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [ ] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 📌 개요
- [✨ feat: OAuth 회원가입 및 로그인 관련 로직 추가](https://github.com/Fill-ENERGY/BackEnd_Server/pull/63/commits/9e1a7afed216f69639da0036f67f5418b7cffca7)
위의 커밋 내용을 집중적으로 확인해주시면 감사하겠습니다.

## 🔎 Key Changes
- commit 과 함께 첨부해주세요

## 💌 To Reviewers
- 실행하고 카카오 로그인을 http://localhost:8080/oauth/kakao/login 진행하고 나온 accessToken으로 회원가입 및 로그인을 진행할 수 있습니다.
- 초기 사용자 닉네임은 이메일에서 @앞까지의 부분으로 들어가도록 구현하였습니다.
- OAuth 관련 .yml 파일 수정사항이 있습니다. 단톡방에 공유해 놓도록 하겠습니다.

## 📸 스크린샷
- 선택사항 입니다.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
