### PR TITLE
✨ feat: 마이페이지 커뮤니티 API 구현 (#71)

### DIFF
--- a/src/main/java/com/example/template/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/template/domain/board/controller/BoardController.java
@@ -32,8 +32,6 @@ public class BoardController {
     private final BoardCommandService boardCommandService;
 
     // QueryService
-    // TODO : 내가 쓴 게시글
-    // TODO : 내가 댓글 단 게시글
     @Operation(summary = "게시글 목록 조회 (전체 및 카테고리별)", description = "커뮤니티 게시글 목록을 전체 또는 카테고리별로 무한 스크롤 방식으로 조회합니다..")
     @GetMapping
     public ApiResponse<BoardResponseDTO.BoardListDTO> getBoardList(
@@ -93,6 +91,7 @@ public class BoardController {
     public ResponseEntity<ApiResponse<BoardResponseDTO.BoardDTO>> createBoard(
             @Valid @RequestBody BoardRequestDTO.CreateBoardDTO createBoardDTO,
             @AuthenticatedMember Member member) {
+        // TODO: 어차피 게시글 목록 페이지로 리다이렉트 되어서, boardId만 Return 하는 방식 고려
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(ApiResponse.onSuccess(HttpStatus.CREATED,

--- a/src/main/java/com/example/template/domain/board/controller/BoardController.java
+++ b/src/main/java/com/example/template/domain/board/controller/BoardController.java
@@ -48,13 +48,40 @@ public class BoardController {
 
     @Operation(summary = "게시글 상세 조회", description = "지정된 ID의 게시글 상세 정보를 조회합니다.")
     @GetMapping("/{boardId}")
-    public ApiResponse<BoardResponseDTO.BoardDetailDTO> getBoardDetail(@PathVariable("boardId") Long boardId,
+    public ApiResponse<BoardResponseDTO.BoardDTO> getBoardDetail(@PathVariable("boardId") Long boardId,
                                                                        @AuthenticatedMember Member member) {
         return ApiResponse.onSuccess(boardQueryService.getBoardDetail(boardId, member));
     }
 
+    @Operation(summary = "내가 쓴 게시글 조회", description = "사용자가 작성한 게시글 목록을 최신순으로 커서 기반 페이지네이션으로 조회합니다.")
+    @GetMapping("/my-posts")
+    public ApiResponse<BoardResponseDTO.BoardListDTO> getMyPosts(
+            @RequestParam(defaultValue = "0") Long cursor,
+            @RequestParam(defaultValue = "10") Integer limit,
+            @AuthenticatedMember Member member) {
+        return ApiResponse.onSuccess(boardQueryService.getMyPosts(cursor, limit, member));
+    }
+
+    @Operation(summary = "내가 댓글 단 게시글 조회", description = "사용자가 댓글을 작성한 게시글 목록을 최신순으로 커서 기반 페이지네이션으로 조회합니다.")
+    @GetMapping("/my-comments")
+    public ApiResponse<BoardResponseDTO.BoardListDTO> getMyCommentedPosts(
+            @RequestParam(defaultValue = "0") Long cursor,
+            @RequestParam(defaultValue = "10") Integer limit,
+            @AuthenticatedMember Member member) {
+        return ApiResponse.onSuccess(boardQueryService.getMyCommentedPosts(cursor, limit, member));
+    }
+
+    @Operation(summary = "내가 좋아요 한 게시글 조회", description = "사용자가 좋아요를 누른 게시글 목록을 최신순으로 커서 기반 페이지네이션으로 조회합니다.")
+    @GetMapping("/my-likes")
+    public ApiResponse<BoardResponseDTO.BoardListDTO> getMyLikedPosts(
+            @RequestParam(defaultValue = "0") Long cursor,
+            @RequestParam(defaultValue = "10") Integer limit,
+            @AuthenticatedMember Member member) {
+        return ApiResponse.onSuccess(boardQueryService.getMyLikedPosts(cursor, limit, member));
+    }
+
     // CommandService
-    @Operation(summary = "이미지 업로드", description = "게시글에 첨부할 이미지를 업로드합니다.")
+    @Operation(summary = "커뮤니티 게시글 이미지 업로드", description = "게시글에 첨부할 이미지를 업로드합니다.")
     @PostMapping(value = "/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<BoardResponseDTO.BoardImgDTO> uploadBoardImages(
             @RequestPart("images") List<MultipartFile> images) {

--- a/src/main/java/com/example/template/domain/board/controller/CommentController.java
+++ b/src/main/java/com/example/template/domain/board/controller/CommentController.java
@@ -39,7 +39,7 @@ public class CommentController {
     }
 
     // CommandService
-    @Operation(summary = "이미지 업로드", description = "댓글에 첨부할 이미지를 업로드합니다.")
+    @Operation(summary = "커뮤니티 댓글 이미지 업로드", description = "댓글에 첨부할 이미지를 업로드합니다.")
     @PostMapping(value = "/comments/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     public ApiResponse<CommentResponseDTO.CommentImgDTO> uploadCommentImages(
             @RequestPart("images") List<MultipartFile> images) {

--- a/src/main/java/com/example/template/domain/board/dto/response/BoardResponseDTO.java
+++ b/src/main/java/com/example/template/domain/board/dto/response/BoardResponseDTO.java
@@ -78,18 +78,6 @@ public class BoardResponseDTO {
 
     @Getter
     @Builder
-    public static class BoardDetailDTO {
-        private BoardDTO board;
-
-        public static BoardDetailDTO of(Board board, Member currentMember) {
-            return BoardDetailDTO.builder()
-                    .board(BoardDTO.from(board, currentMember.getId()))
-                    .build();
-        }
-    }
-
-    @Getter
-    @Builder
     public static class BoardStatusDTO {
         private Long boardId;
         private String helpStatus;

--- a/src/main/java/com/example/template/domain/board/exception/CommentErrorCode.java
+++ b/src/main/java/com/example/template/domain/board/exception/CommentErrorCode.java
@@ -14,7 +14,8 @@ public enum CommentErrorCode implements BaseErrorCode {
     COMMENT_BOARD_MISMATCH(HttpStatus.BAD_REQUEST, "COMMENT400", "댓글이 해당 게시글에 속하지 않습니다."),
     INVALID_IMAGE_URLS(HttpStatus.BAD_REQUEST, "COMMENT400", "일부 이미지 URL이 유효하지 않거나 찾을 수 없습니다."),
     PARENT_COMMENT_NOT_FOUND(HttpStatus.BAD_REQUEST, "COMMENT400", "부모 댓글을 찾을 수 없거나 해당 게시글에 속하지 않습니다."),
-    NESTED_REPLY_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "COMMENT400", "대댓글에 대한 답글은 작성할 수 없습니다.");
+    NESTED_REPLY_NOT_ALLOWED(HttpStatus.BAD_REQUEST, "COMMENT400", "대댓글에 대한 답글은 작성할 수 없습니다."),
+    COMMENT_ALREADY_DELETED(HttpStatus.BAD_REQUEST,"COMMENT400","이미 삭제된 댓글은 수정할 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/example/template/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/template/domain/board/repository/BoardRepository.java
@@ -26,20 +26,13 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     @Query("SELECT b FROM Board b WHERE b.category = :category AND b.id < :cursor ORDER BY b.id DESC")
     List<Board> findByCategoryOrderByLatestWithCursor(@Param("category") Category category, @Param("cursor") Long cursor, Pageable pageable);
 
-    default List<Board> findAllOrderByLikesWithCursor(Long cursor, Integer limit) {
-        return findAllOrderByLikesWithCursor(cursor, PageRequest.of(0, limit));
-    }
+    @Query("SELECT b FROM Board b WHERE b.member.id = :memberId AND b.id < :cursor ORDER BY b.id DESC")
+    List<Board> findMyPosts(@Param("memberId") Long memberId, @Param("cursor") Long cursor, Pageable pageable);
 
-    default List<Board> findAllOrderByLatestWithCursor(Long cursor, Integer limit) {
-        return findAllOrderByLatestWithCursor(cursor, PageRequest.of(0, limit));
-    }
+    @Query("SELECT DISTINCT b FROM Board b JOIN b.comments c WHERE c.member.id = :memberId AND b.id < :cursor ORDER BY b.id DESC")
+    List<Board> findMyCommentedPosts(@Param("memberId") Long memberId, @Param("cursor") Long cursor, Pageable pageable);
 
-    default List<Board> findByCategoryOrderByLikesWithCursor(Category category, Long cursor, Integer limit) {
-        return findByCategoryOrderByLikesWithCursor(category, cursor, PageRequest.of(0, limit));
-    }
-
-    default List<Board> findByCategoryOrderByLatestWithCursor(Category category, Long cursor, Integer limit) {
-        return findByCategoryOrderByLatestWithCursor(category, cursor, PageRequest.of(0, limit));
-    }
+    @Query("SELECT b FROM Board b JOIN BoardLike bl ON b.id = bl.board.id WHERE bl.member.id = :memberId AND b.id < :cursor ORDER BY b.id DESC")
+    List<Board> findMyLikedPosts(@Param("memberId") Long memberId, @Param("cursor") Long cursor, Pageable pageable);
 }
 

--- a/src/main/java/com/example/template/domain/board/service/commandService/CommentCommandServiceImpl.java
+++ b/src/main/java/com/example/template/domain/board/service/commandService/CommentCommandServiceImpl.java
@@ -132,6 +132,12 @@ public class CommentCommandServiceImpl implements  CommentCommandService{
                 .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
         validateCommentOwnership(comment, member);
 
+        // 삭제된 댓글 수정 시도 체크
+        if (comment.isDeleted()) {
+            throw new CommentException(CommentErrorCode.COMMENT_ALREADY_DELETED);
+        }
+
+        // 댓글이 해당 게시글에 속하지 않는 경우
         if (!comment.getBoard().getId().equals(boardId)) {
             throw new CommentException(CommentErrorCode.COMMENT_BOARD_MISMATCH);
         }
@@ -139,6 +145,7 @@ public class CommentCommandServiceImpl implements  CommentCommandService{
         comment.setContent(updateDTO.getContent());
         comment.setSecret(updateDTO.isSecret());
 
+        // 이미지 처리
         if (updateDTO.getImages() != null) {
             List<String> currentImageUrls = comment.getImages().stream()
                     .map(CommentImg::getCommentImgUrl)

--- a/src/main/java/com/example/template/domain/board/service/commandService/CommentCommandServiceImpl.java
+++ b/src/main/java/com/example/template/domain/board/service/commandService/CommentCommandServiceImpl.java
@@ -130,12 +130,12 @@ public class CommentCommandServiceImpl implements  CommentCommandService{
     public CommentResponseDTO.CommentDTO updateComment(Long boardId, Long commentId, CommentRequestDTO.UpdateDTO updateDTO, Member member) {
         Comment comment = commentRepository.findById(commentId)
                 .orElseThrow(() -> new CommentException(CommentErrorCode.COMMENT_NOT_FOUND));
-        validateCommentOwnership(comment, member);
-
         // 삭제된 댓글 수정 시도 체크
         if (comment.isDeleted()) {
             throw new CommentException(CommentErrorCode.COMMENT_ALREADY_DELETED);
         }
+
+        validateCommentOwnership(comment, member);
 
         // 댓글이 해당 게시글에 속하지 않는 경우
         if (!comment.getBoard().getId().equals(boardId)) {

--- a/src/main/java/com/example/template/domain/board/service/queryService/BoardQueryService.java
+++ b/src/main/java/com/example/template/domain/board/service/queryService/BoardQueryService.java
@@ -13,5 +13,11 @@ public interface BoardQueryService {
                                                SortType sortType,
                                                Member member);
 
-    BoardResponseDTO.BoardDetailDTO getBoardDetail(Long boardId, Member member);
+    BoardResponseDTO.BoardDTO getBoardDetail(Long boardId, Member member);
+
+    BoardResponseDTO.BoardListDTO getMyPosts(Long cursor, Integer limit, Member member);
+
+    BoardResponseDTO.BoardListDTO getMyCommentedPosts(Long cursor, Integer limit, Member member);
+
+    BoardResponseDTO.BoardListDTO getMyLikedPosts(Long cursor, Integer limit, Member member);
 }

--- a/src/main/java/com/example/template/domain/board/service/queryService/BoardQueryServiceImpl.java
+++ b/src/main/java/com/example/template/domain/board/service/queryService/BoardQueryServiceImpl.java
@@ -9,6 +9,7 @@ import com.example.template.domain.board.exception.BoardException;
 import com.example.template.domain.board.repository.BoardRepository;
 import com.example.template.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -27,35 +28,66 @@ public class BoardQueryServiceImpl implements BoardQueryService {
                                                       Integer limit,
                                                       SortType sortType,
                                                       Member member) {
-        // 첫 페이지 로딩 시 매우 큰 ID 값 사용
-        if (cursor == 0) {
-            cursor = Long.MAX_VALUE;
-        }
-
-        List<Board> boards;
-        // 전체 조회
-        if (category == null) {
-            boards = sortType == SortType.LIKES
-                    ? boardRepository.findAllOrderByLikesWithCursor(cursor, limit)
-                    : boardRepository.findAllOrderByLatestWithCursor(cursor, limit);
-        }
-        // 카테고리별 조회
-        else {
-            boards = sortType == SortType.LIKES
-                    ? boardRepository.findByCategoryOrderByLikesWithCursor(category, cursor, limit)
-                    : boardRepository.findByCategoryOrderByLatestWithCursor(category, cursor, limit);
-        }
-
-        Long nextCursor = boards.isEmpty() ? null : boards.get(boards.size() - 1).getId();
-        boolean hasNext = boards.size() == limit;
-
-        return BoardResponseDTO.BoardListDTO.of(boards, nextCursor, hasNext, member.getId());
+        cursor = initializeCursor(cursor);
+        List<Board> boards = fetchBoards(category, cursor, limit, sortType);
+        return createBoardListDTO(boards, limit, member.getId());
     }
 
     @Override
-    public BoardResponseDTO.BoardDetailDTO getBoardDetail(Long boardId, Member member) {
+    public BoardResponseDTO.BoardDTO getBoardDetail(Long boardId, Member member) {
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new BoardException(BoardErrorCode.BOARD_NOT_FOUND));
-        return BoardResponseDTO.BoardDetailDTO.of(board, member);
+        return BoardResponseDTO.BoardDTO.from(board, member.getId());
+    }
+
+    public BoardResponseDTO.BoardListDTO getMyPosts(Long cursor, Integer limit, Member member) {
+        cursor = initializeCursor(cursor);
+        PageRequest pageRequest = PageRequest.of(0, limit + 1);
+        List<Board> boards = boardRepository.findMyPosts(member.getId(), cursor, pageRequest);
+        return createBoardListDTO(boards, limit, member.getId());
+    }
+
+    public BoardResponseDTO.BoardListDTO getMyCommentedPosts(Long cursor, Integer limit, Member member) {
+        cursor = initializeCursor(cursor);
+        PageRequest pageRequest = PageRequest.of(0, limit + 1);
+        List<Board> boards = boardRepository.findMyCommentedPosts(member.getId(), cursor, pageRequest);
+        return createBoardListDTO(boards, limit, member.getId());
+    }
+
+    public BoardResponseDTO.BoardListDTO getMyLikedPosts(Long cursor, Integer limit, Member member) {
+        cursor = initializeCursor(cursor);
+        PageRequest pageRequest = PageRequest.of(0, limit + 1);
+        List<Board> boards = boardRepository.findMyLikedPosts(member.getId(), cursor, pageRequest);
+        return createBoardListDTO(boards, limit, member.getId());
+    }
+
+    private Long initializeCursor(Long cursor) {
+        return (cursor == 0) ? Long.MAX_VALUE : cursor;
+    }
+
+    private List<Board> fetchBoards(Category category, Long cursor, Integer limit, SortType sortType) {
+        PageRequest pageRequest = PageRequest.of(0, limit + 1);
+        if (category == null) {
+            if (sortType == SortType.LIKES) {
+                return boardRepository.findAllOrderByLikesWithCursor(cursor, pageRequest);
+            } else {
+                return boardRepository.findAllOrderByLatestWithCursor(cursor, pageRequest);
+            }
+        } else {
+            if (sortType == SortType.LIKES) {
+                return boardRepository.findByCategoryOrderByLikesWithCursor(category, cursor, pageRequest);
+            } else {
+                return boardRepository.findByCategoryOrderByLatestWithCursor(category, cursor, pageRequest);
+            }
+        }
+    }
+
+    private BoardResponseDTO.BoardListDTO createBoardListDTO(List<Board> boards, Integer limit, Long memberId) {
+        boolean hasNext = boards.size() > limit;
+        if (hasNext) {
+            boards = boards.subList(0, limit);
+        }
+        Long nextCursor = hasNext ? boards.get(boards.size() - 1).getId() : null;
+        return BoardResponseDTO.BoardListDTO.of(boards, nextCursor, hasNext, memberId);
     }
 }

--- a/src/main/java/com/example/template/domain/board/service/queryService/CommentQueryServiceImpl.java
+++ b/src/main/java/com/example/template/domain/board/service/queryService/CommentQueryServiceImpl.java
@@ -1,11 +1,7 @@
 package com.example.template.domain.board.service.queryService;
 
 import com.example.template.domain.board.dto.response.CommentResponseDTO;
-import com.example.template.domain.board.entity.Board;
 import com.example.template.domain.board.entity.Comment;
-import com.example.template.domain.board.exception.BoardErrorCode;
-import com.example.template.domain.board.exception.BoardException;
-import com.example.template.domain.board.repository.BoardRepository;
 import com.example.template.domain.board.repository.CommentRepository;
 import com.example.template.domain.member.entity.Member;
 import lombok.RequiredArgsConstructor;
@@ -22,7 +18,6 @@ import java.util.List;
 public class CommentQueryServiceImpl implements CommentQueryService {
 
     private final CommentRepository commentRepository;
-    private final BoardRepository boardRepository;
 
     @Override
     public CommentResponseDTO.CommentsListDTO getCommentsList(Long boardId, Member member) {

--- a/src/main/java/com/example/template/domain/member/controller/MemberController.java
+++ b/src/main/java/com/example/template/domain/member/controller/MemberController.java
@@ -40,7 +40,6 @@ public class MemberController {
         return ApiResponse.onSuccess(kakaoService.loginOrSignupByKakao(requestDTO));
     }
 
-
     @Operation(summary = "로그아웃")
     @PostMapping("/logout")
     public ApiResponse<String> logout(HttpServletRequest request) {


### PR DESCRIPTION
## ☝️Issue Number
- resolve #71 

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 📌 개요
- ✨ feat: 마이페이지 커뮤니티 API 구현 (#71)

## 🔎 Key Changes
- [✨ feat: 마이페이지 커뮤니티 API 구현](https://github.com/Fill-ENERGY/BackEnd_Server/commit/072328d0abb1d3a0d0a5d172053f7a2dd9eb759d)
  - 내가 쓴 게시글, 댓글 단 게시글, 좋아요 한 게시글 구현 완료
- [♻️ refactor: 댓글 ResponseDTO 수정, 비밀 댓글 이미지 처리 수정](https://github.com/Fill-ENERGY/BackEnd_Server/pull/72/commits/cd64c73c860d3f6e7bce47196262541bf2f2c8a8)
  - 댓글 응답 DTO에서 secret, deleted, canViewSecret 필드 제거
  ~~~
  - author
      - 현재 사용자가 댓글 작성자인지 여부 입니다.
          - true인 경우: 댓글 수정/삭제 옵션을 표시
          - false인 경우: 차단하기 / 신고하기 옵션을 표시
  - 민감한 정보(삭제/비밀 댓글)은 서버에서 계산해서 보내줍니다.
      - SoftDeleted된 댓글의 경우
          - memberId가 null,
          memberName이 "(삭제)",
          content가 “댓글이 삭제되었습니다.” 로 response가 구성됩니다.
      - 현재 사용자가 비밀 댓글을 볼 수 없는 경우 (게시글 작성자 & 댓글본인 제외)
          - content가 “비밀 댓글입니다.”,
          images: [] 로 response가 구성됩니다.
     ~~~
- [♻️ refactor: 삭제된 댓글 수정 시도하는 경우 에러 추가](https://github.com/Fill-ENERGY/BackEnd_Server/pull/72/commits/20a4bfa40d7035ccd5909d650b949a0db25e3b18)

## 💌 To Reviewers
- 리뷰어가 참고해야 하는 내용

## 📸 스크린샷
- 선택사항 입니다.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
