### PR TITLE
🐛 fix: 좋아요순 정렬 커뮤니티 게시글 목록 GET API 수정 (#84)

### DIFF
--- a/src/main/java/com/example/template/domain/board/entity/Board.java
+++ b/src/main/java/com/example/template/domain/board/entity/Board.java
@@ -30,7 +30,7 @@ public class Board extends BaseEntity {
     private String content;   // 내용
 
     @Enumerated(EnumType.STRING)
-    @Column(nullable = false)
+    @Column(name = "category", nullable = false)
     private Category category;     // 카테고리
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/template/domain/board/repository/BoardRepository.java
+++ b/src/main/java/com/example/template/domain/board/repository/BoardRepository.java
@@ -14,14 +14,38 @@ import java.util.List;
 
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
-    @Query("SELECT b FROM Board b WHERE b.id < :cursor ORDER BY b.likeNum DESC, b.id DESC")
-    List<Board> findAllOrderByLikesWithCursor(@Param("cursor") Long cursor, Pageable pageable);
+    // 좋아요 순 정렬 - 전체 게시물 (첫 페이지)
+    @Query("SELECT b FROM Board b ORDER BY b.likeNum DESC, b.id DESC")
+    List<Board> findAllOrderByLikesFirstPage(Pageable pageable);
+
+    // 좋아요 순 정렬 - 전체 게시물 (이후 페이지)
+    @Query(value = "SELECT b1.* FROM board b1 " +
+            "JOIN (SELECT b2.board_id, CONCAT(LPAD(CAST(b2.like_num AS CHAR(10)), 10, '0'), LPAD(CAST(b2.board_id AS CHAR(10)), 10, '0')) as cursorValue " +
+            "      FROM board b2) as cursorTable ON cursorTable.board_id = b1.board_id " +
+            "WHERE cursorValue < (SELECT CONCAT(LPAD(CAST(b3.like_num AS CHAR(10)), 10, '0'), LPAD(CAST(b3.board_id AS CHAR(10)), 10, '0')) " +
+            "                                FROM board b3 WHERE b3.board_id = :cursor) " +
+            "ORDER BY b1.like_num DESC, b1.board_id DESC " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<Board> findAllOrderByLikesWithCursor(@Param("cursor") Long cursor, @Param("limit") int limit);
+
+    // 좋아요 순 정렬 - 카테고리별 (첫 페이지)
+    @Query("SELECT b FROM Board b WHERE b.category = :category ORDER BY b.likeNum DESC, b.id DESC")
+    List<Board> findByCategoryOrderByLikesFirstPage(@Param("category") Category category, Pageable pageable);
+
+    // 좋아요 순 정렬 - 카테고리별 (이후 페이지)
+    @Query(value = "SELECT b1.* FROM board b1 " +
+            "JOIN (SELECT b2.board_id, CONCAT(LPAD(CAST(b2.like_num AS CHAR(10)), 10, '0'), LPAD(CAST(b2.board_id AS CHAR(10)), 10, '0')) as cursorValue " +
+            "      FROM board b2 ) as cursorTable ON cursorTable.board_id = b1.board_id " +
+            "WHERE cursorValue < (SELECT CONCAT(LPAD(CAST(b3.like_num AS CHAR(10)), 10, '0'), LPAD(CAST(b3.board_id AS CHAR(10)), 10, '0')) " +
+            "                                FROM board b3 WHERE b3.board_id = :cursor AND b3.category = :#{#category.name()})  " +
+            "ORDER BY b1.like_num DESC, b1.board_id DESC " +
+            "LIMIT :limit",
+            nativeQuery = true)
+    List<Board> findByCategoryOrderByLikesWithCursor(@Param("category") Category category, @Param("cursor") Long cursor, @Param("limit") int limit);
 
     @Query("SELECT b FROM Board b WHERE b.id < :cursor ORDER BY b.id DESC")
     List<Board> findAllOrderByLatestWithCursor(@Param("cursor") Long cursor, Pageable pageable);
-
-    @Query("SELECT b FROM Board b WHERE b.category = :category AND b.id < :cursor ORDER BY b.likeNum DESC, b.id DESC")
-    List<Board> findByCategoryOrderByLikesWithCursor(@Param("category") Category category, @Param("cursor") Long cursor, Pageable pageable);
 
     @Query("SELECT b FROM Board b WHERE b.category = :category AND b.id < :cursor ORDER BY b.id DESC")
     List<Board> findByCategoryOrderByLatestWithCursor(@Param("category") Category category, @Param("cursor") Long cursor, Pageable pageable);


### PR DESCRIPTION
## ☝️Issue Number
- resolve #84 

## 📍 PR 타입 (하나 이상 선택)
- [x] 기능 추가
- [x] 버그 수정
- [x] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 📌 개요
- 🐛 fix: 좋아요순 정렬 커뮤니티 게시글 목록 GET API 수정 (#84)

## 🔎 Key Changes
- 3b984048941ad9647b100e10304105cb150db1f4

## 💌 To Reviewers
- [참고 링크](https://velog.io/@minsangk/%EC%BB%A4%EC%84%9C-%EA%B8%B0%EB%B0%98-%ED%8E%98%EC%9D%B4%EC%A7%80%EB%84%A4%EC%9D%B4%EC%85%98-Cursor-based-Pagination-%EA%B5%AC%ED%98%84%ED%95%98%EA%B8%B0)

## 📸 스크린샷
- 선택사항 입니다.

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
