### PR TITLE
🐛 fix: 채팅방 목록 조회 쿼리 및 페이징 처리 로직 수정 (#86)

### DIFF
--- a/src/main/java/com/example/template/domain/block/controller/BlockController.java
+++ b/src/main/java/com/example/template/domain/block/controller/BlockController.java
@@ -7,6 +7,8 @@ import com.example.template.domain.member.entity.Member;
 import com.example.template.global.annotation.AuthenticatedMember;
 import com.example.template.global.apiPayload.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.Parameters;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -29,6 +31,10 @@ public class BlockController {
 
     @GetMapping("/blocks/members")
     @Operation(summary = "차단 목록 조회", description = "멤버가 차단한 목록을 조회합니다. 차단 목록이 없으면 빈 배열을 반환합니다.")
+    @Parameters({
+            @Parameter(name = "cursor", description = "마지막 차단 id(blockId)"),
+            @Parameter(name = "limit", description = "가져올 차단 내역 개수, default = 10"),
+    })
     public ApiResponse<BlockResponseDTO.BlockListDTO> getBlockList(@RequestParam(defaultValue = "0") Long cursor,
                                                                          @RequestParam(defaultValue = "10") Integer limit,
                                                                          @AuthenticatedMember Member member) {

--- a/src/main/java/com/example/template/domain/block/service/BlockQueryServiceImpl.java
+++ b/src/main/java/com/example/template/domain/block/service/BlockQueryServiceImpl.java
@@ -24,13 +24,15 @@ public class BlockQueryServiceImpl implements BlockQueryService{
             cursor = Long.MAX_VALUE;
         }
 
-        List<Block> blocks = blockRepository.findByMemberWithCursor(cursor, limit, member);
+        List<Block> blocks = blockRepository.findByMemberWithCursor(cursor, limit + 1, member);
+
+        boolean hasNext = blocks.size() > limit;
+        if (hasNext) {
+            blocks = blocks.subList(0, limit);
+        }
 
         Long nextCursor = blocks.isEmpty() ? null : blocks.get(blocks.size() - 1).getId();
-        boolean hasNext = blocks.size() == limit;
-
 
         return BlockResponseDTO.BlockListDTO.of(blocks, nextCursor, hasNext);
-
     }
 }

--- a/src/main/java/com/example/template/domain/message/controller/MessageController.java
+++ b/src/main/java/com/example/template/domain/message/controller/MessageController.java
@@ -61,7 +61,7 @@ public class MessageController {
     @Operation(summary = "쪽지 목록 조회", description = "채팅방의 쪽지 목록을 조회합니다.")
     @Parameters({
             @Parameter(name = "cursor", description = "마지막 쪽지 id(messageId)"),
-            @Parameter(name = "limit", description = "가져올 채팅방 개수, default = 10"),
+            @Parameter(name = "limit", description = "가져올 쪽지 개수, default = 10"),
     })
     public ApiResponse<MessageResponseDTO.MessageListDTO> getMessageList(@PathVariable("threadId") Long threadId,
                                                                          @RequestParam(defaultValue = "0") Long cursor,
@@ -75,7 +75,7 @@ public class MessageController {
     @Operation(summary = "쪽지 목록 조회 및 읽음 상태 업데이트", description = "채팅방의 쪽지 목록을 조회하고 읽지 않은 쪽지를 읽음으로 업데이트합니다.")
     @Parameters({
             @Parameter(name = "cursor", description = "마지막 쪽지 id(messageId)"),
-            @Parameter(name = "limit", description = "가져올 채팅방 개수, default = 10"),
+            @Parameter(name = "limit", description = "가져올 쪽지 개수, default = 10"),
     })
     public ApiResponse<MessageResponseDTO.MessageListDTO> updateMessageList(@PathVariable("threadId") Long threadId,
                                                                             @RequestParam(defaultValue = "0") Long cursor,

--- a/src/main/java/com/example/template/domain/message/entity/Message.java
+++ b/src/main/java/com/example/template/domain/message/entity/Message.java
@@ -21,6 +21,7 @@ public class Message extends BaseEntity {
     @Column(name = "message_id", nullable = false)
     private Long id;
 
+    @Lob
     private String content; // 내용
 
     @Enumerated(EnumType.STRING)

--- a/src/main/java/com/example/template/domain/message/repository/MessageParticipantRepository.java
+++ b/src/main/java/com/example/template/domain/message/repository/MessageParticipantRepository.java
@@ -22,11 +22,11 @@ public interface MessageParticipantRepository extends JpaRepository<MessageParti
     @Query("SELECT mp FROM MessageParticipant mp " +
             "WHERE mp.member = :member " +
             "AND mp.participationStatus = :status " +
-            "AND mp.messageThread.updatedAt < :cursor " +
-            "AND mp.messageThread.id < :lastId " +
+            "AND (mp.messageThread.updatedAt < :cursor " +
+            "OR (mp.messageThread.updatedAt = :cursor AND mp.messageThread.id < :lastId)) " +
             "AND mp.messageThread.id NOT IN (SELECT mt.id FROM MessageThread mt " +
             "JOIN mt.participants p WHERE p.member IN :blockedMembers) " +
-            "ORDER BY mp.messageThread.updatedAt DESC")
+            "ORDER BY mp.messageThread.updatedAt DESC, mp.messageThread.id DESC")
     List<MessageParticipant> findByMemberAndParticipationStatusWithCursor(
             @Param("member") Member member,
             @Param("status") ParticipationStatus status,


### PR DESCRIPTION
## ☝️Issue Number
- resolve #86 

## 📍 PR 타입 (하나 이상 선택)
- [ ] 기능 추가
- [x] 버그 수정
- [ ] 의존성, 환경 변수, 빌드 관련 코드 업데이트
- [x] 기타 사소한 수정

## 📌 개요
- #86 

## 🔎 Key Changes
- [🐛 fix: 채팅방 목록 조회 쿼리 수정](https://github.com/Fill-ENERGY/BackEnd_Server/commit/5dbc32641c4d9268997334c4c904ceb20c5368a8)
<br/>

- 데이터 개수와 limit이 동일할 때, 다음 페이지가 존재하지 않는데 hasNext가 true로 표시되는 문제를 해결했습니다. 
   limit + 1 개의 항목을 조회하여 다음 페이지 존재 여부를 확인하도록 수정했습니다.
  - [♻️ refactor: 쪽지, 차단 페이징 처리 수정 - limit + 1 방식으로 항목을 조회하여 다음 페이지 여부 확인](https://github.com/Fill-ENERGY/BackEnd_Server/commit/9b658244f74c90478ea7f3746714ca2ace98e421)

## ✅ 체크 리스트
- [x] PR 템플릿에 맞추어 작성했어요.
- [x] 변경 내용에 대한 테스트를 진행했어요.
- [x] 프로그램이 정상적으로 동작해요.
- [x] PR에 적절한 라벨을 선택했어요.
- [x] 불필요한 코드는 삭제했어요.
